### PR TITLE
improvement/pc_launch_guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ roslaunch finite_state_machine <mission_script>.launch
 ```
 
 For manual operation, execute the joystick nodes on the topside computer connected to the drone:
+Refer to the guide in [this README](./auv_setup/README.md) for how to set up the joystick and the topside pc.
 ```
 roslaunch auv_setup pc.launch
 ```
+
 
 ## Documentation
 * TODO: Drivers and hardware specifics for each drone will be added to the wiki. Link them here.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ roslaunch finite_state_machine <mission_script>.launch
 ```
 
 For manual operation, execute the joystick nodes on the topside computer connected to the drone:
-Refer to the guide in [this README](./auv_setup/README.md) for how to set up the joystick and the topside pc.
 ```
 roslaunch auv_setup pc.launch
 ```
-
+Refer to the guide in [this README](./auv_setup/README.md) for how to set up the joystick and the topside pc.
 
 ## Documentation
 * TODO: Drivers and hardware specifics for each drone will be added to the wiki. Link them here.

--- a/auv_setup/README.md
+++ b/auv_setup/README.md
@@ -19,11 +19,14 @@ For the AUV launchfiles, the following parameters can be used:
 | ----------|-----------------|-----------|
 | type      | real, simulator | simulator |
 
-#### pc.launch
-The pc.launch file is to be run on the topside computer, which needs to be connected to the same network as the drone.
-The drone will be the master, and the topside computer needs to know how to connect to the drone. To configure this, do the following:
+#### ROV mode topside launch
+We make no distinction for launching in AUV or ROV mode for the system running on the physical drone.
+You will however need to run the pc.launch file on the topside computer in order to operate the drone
+with a joystick. The topside computer needs to be connected to the same network as the drone. In our configuration, the drone
+is the master node, while the topside computer is the slave. For the slave to know how to connect to the master node,
+you will need to configure the topside computer:
 
-1. Find the IP of the Xavier. When running the Xavier on the drone, this should be `10.42.0.1`.
+1. Find the IP of the master. When running the Xavier on the drone, this should be `10.42.0.1`.
 2. On the topside computer, execute
 ```echo "source vortex_ws/devel/setup.bash" >> ~/.bashrc
 echo "export ROS_MASTER_URI=http://X.X.X.X:11311" >> ~/.bashrc

--- a/auv_setup/README.md
+++ b/auv_setup/README.md
@@ -28,7 +28,7 @@ you will need to configure the topside computer:
 
 1. Find the IP of the master. When running the Xavier on the drone, this should be `10.42.0.1`.
 2. On the topside computer, execute
-```echo "source vortex_ws/devel/setup.bash" >> ~/.bashrc
+```
 echo "export ROS_MASTER_URI=http://X.X.X.X:11311" >> ~/.bashrc
 ```
 where X.X.X.X is the IP of the Xavier.

--- a/auv_setup/README.md
+++ b/auv_setup/README.md
@@ -19,6 +19,21 @@ For the AUV launchfiles, the following parameters can be used:
 | ----------|-----------------|-----------|
 | type      | real, simulator | simulator |
 
+#### pc.launch
+The pc.launch file is to be run on the topside computer, which needs to be connected to the same network as the drone.
+The drone will be the master, and the topside computer needs to know how to connect to the drone. To configure this, do the following:
+
+1. Find the IP of the Xavier. When running the Xavier on the drone, this should be `10.42.0.1`.
+2. On the topside computer, execute
+```echo "source vortex_ws/devel/setup.bash" >> ~/.bashrc
+echo "export ROS_MASTER_URI=http://X.X.X.X:11311" >> ~/.bashrc
+```
+where X.X.X.X is the IP of the Xavier.
+
+3. Source the newly edited file.
+```
+source ~/.bashrc
+```
 
 ### Sensors
 Currently, the AUV launchfiles also contain the sensor driver launches, including the remapping of them:


### PR DESCRIPTION
Adding a simple guide for setting up the topside computer to communicate with the roscore on the drone. A more comprehensive guide will be added to the wiki during the next pooltest, where we 100% will run into unforeseen problems :wink: 