### PR TITLE
Remove ThrusterForces msg, move sanity check and fix a typo

### DIFF
--- a/motion/thruster_allocator/include/vortex_allocator/allocator_ros.h
+++ b/motion/thruster_allocator/include/vortex_allocator/allocator_ros.h
@@ -30,7 +30,6 @@ private:
   std::unique_ptr<PseudoinverseAllocator> m_pseudoinverse_allocator;
 
   Eigen::VectorXd rovForcesMsgToEigen(const geometry_msgs::Wrench &msg) const;
-  bool healthyWrench(const Eigen::VectorXd &v) const;
 };
 
 #endif  // VORTEX_ALLOCATOR_ALLOCATOR_ROS_H

--- a/motion/thruster_allocator/include/vortex_allocator/eigen_helper.h
+++ b/motion/thruster_allocator/include/vortex_allocator/eigen_helper.h
@@ -1,7 +1,7 @@
 #ifndef VORTEX_EIGEN_HELPER_H
 #define VORTEX_EIGEN_HELPER_H
 
-#include "vortex_msgs/ThrusterForces.h"
+#include "std_msgs/Float32MultiArray.h"
 #include "ros/ros.h"
 #include <Eigen/Dense>
 
@@ -71,13 +71,13 @@ inline Eigen::Matrix3d skew(const Eigen::Vector3d &v)
   return S;
 }
 
-inline void arrayEigenToMsg(const Eigen::VectorXd &u, vortex_msgs::ThrusterForces *msg)
+inline void arrayEigenToMsg(const Eigen::VectorXd &u, std_msgs::Float32MultiArray *msg)
 {
   int r = u.size();
-  std::vector<double> u_vec(r);
+  std::vector<float> u_vec(r);
   for (int i = 0; i < r; ++i)
     u_vec[i] = u(i);
-  msg->thrust = u_vec;
+  msg->data = u_vec;
 }
 
 // Saturate all elements of vector v to within [min, max].

--- a/navigation/navigation_launch/launch/navigation.launch
+++ b/navigation/navigation_launch/launch/navigation.launch
@@ -16,7 +16,7 @@
     <group if="$(eval localization == 'eskf')">
       
       <!-- Error State Kalman Filter-->
-      <node pkg="eskf" type="eskf" name="eskf_localization_node" clear_params="true" output="screen" />
+      <node pkg="eskf" type="eskf" name="eskf_localization_node" clear_params="true" output="screen">
 	      <rosparam file="$(find eskf)/apps/ros/parameters/pooltest2021_params.yaml" /> 
       </node>
 


### PR DESCRIPTION
This PR does three things

- Replace vortex_msgs/ThrusterForces with std_msgs/Float32MultiArray. Our custom-made msg adds no functionality and can thus be replaced.
- Move sanity check from allocation to thruster interface. This is done because the sanity check is hardware-dependent and has a much better existing implementation in thruster interface
- Fix a typo in navigation.launch

This PR should be merged together with the one in PCA9685_thruster_interface