### PR TITLE
Added the feature

### DIFF
--- a/motion/thruster_interface_auv/thruster_interface_auv/thruster_interface_auv_driver_lib.py
+++ b/motion/thruster_interface_auv/thruster_interface_auv/thruster_interface_auv_driver_lib.py
@@ -18,12 +18,11 @@ class ThrusterInterfaceAUVDriver:
                  PWM_MIN=[1100, 1100, 1100, 1100, 1100, 1100, 1100, 1100],
                  PWM_MAX=[1900, 1900, 1900, 1900, 1900, 1900, 1900, 1900]):
         # Initialice the I2C comunication
+        self.bus = None
         try:
             self.bus = smbus2.SMBus(I2C_BUS)
         except Exception as errorCode:
-            print(
-                f"ERROR: Failed connection I2C buss nr {self.bus}: {errorCode}"
-            )
+            print(f"ERROR: Failed connection I2C buss nr {self.bus}: {errorCode}")
         self.PICO_I2C_ADDRESS = PICO_I2C_ADDRESS
 
         # Set mapping, direction and offset for the thrusters

--- a/motion/thruster_interface_auv/thruster_interface_auv/thruster_interface_auv_driver_lib.py
+++ b/motion/thruster_interface_auv/thruster_interface_auv/thruster_interface_auv_driver_lib.py
@@ -22,7 +22,9 @@ class ThrusterInterfaceAUVDriver:
         try:
             self.bus = smbus2.SMBus(I2C_BUS)
         except Exception as errorCode:
-            print(f"ERROR: Failed connection I2C buss nr {self.bus}: {errorCode}")
+            print(
+                f"ERROR: Failed connection I2C buss nr {self.bus}: {errorCode}"
+            )
         self.PICO_I2C_ADDRESS = PICO_I2C_ADDRESS
 
         # Set mapping, direction and offset for the thrusters


### PR DESCRIPTION
Again, made the necesarry changes to make sure thruster_interface_auv can run withouth I2C. It will give out manny warnings/errors, but will stil run even with errors present. Tested the code on a new machine and the code runs even if no I2C is detected jesjes