### PR TITLE
Add CI pipeline and .repos file for building and dependency management

### DIFF
--- a/.github/workflows/source-build.yaml
+++ b/.github/workflows/source-build.yaml
@@ -1,0 +1,54 @@
+name: Source Build
+
+on:
+  pull_request:
+
+  # runs daily to check for dependency issues or flaking tests
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Setup ROS 2 Environment
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: ros2_ws/src/${{ github.event.repository.name }}
+
+      - name: Import Dependencies with vcs
+        run: |
+          cd ${{ github.workspace }}/ros2_ws/src
+          vcs import . < ${{ github.workspace }}/ros2_ws/src/${{ github.event.repository.name }}/ros2.repos
+
+      - name: Install Package Dependencies with rosdep
+        run: |
+          cd ${{ github.workspace }}/ros2_ws
+          source /opt/ros/humble/setup.bash
+
+          rosdep update
+          rosdep install --from-paths src --ignore-src -r -y
+
+      - name: Build ROS 2 Workspace
+        run: |
+          cd ${{ github.workspace }}/ros2_ws
+          source /opt/ros/humble/setup.bash
+          colcon build --event-handlers console_cohesion+
+
+      - name: Run Tests
+        run: |
+          cd ${{ github.workspace }}/ros2_ws
+          source /opt/ros/humble/setup.bash
+          colcon test --event-handlers console_direct+
+
+      - name: Test Results Summary
+        run: |
+          cd ${{ github.workspace }}/ros2_ws
+          source /opt/ros/humble/setup.bash
+          colcon test-result --verbose

--- a/auv_setup/package.xml
+++ b/auv_setup/package.xml
@@ -9,9 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/mission/joystick_interface_auv/package.xml
+++ b/mission/joystick_interface_auv/package.xml
@@ -16,8 +16,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>ros2launch</exec_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
 
   <export>

--- a/motion/thrust_allocator_auv/package.xml
+++ b/motion/thrust_allocator_auv/package.xml
@@ -14,9 +14,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ros2.repos
+++ b/ros2.repos
@@ -1,0 +1,4 @@
+repositories:
+  vortex_msgs:
+    type: git
+    url: https://github.com/vortexntnu/vortex-msgs.git


### PR DESCRIPTION
This PR introduces the following changes:

- Adds a GitHub Actions CI pipeline to automatically build and test the ROS 2 source code.
- Includes a `.repos` file for managing external dependencies (e.g., vortex_msgs) using vcs.
- The pipeline includes a daily scheduled run at 3:00 AM (UTC) to detect flaky tests and dependency issues.
- The pipeline triggers on all pull requests to ensure all branches are built and tested.

Purpose:
- Automate the testing and building process for ROS 2 projects.
- Ensure external dependencies are managed efficiently and consistently.
- Schedule daily checks to catch potential issues with dependencies or tests