### PR TITLE
fix: update simulator launch command for testing

### DIFF
--- a/tests/waypoint_navigation/simulator_test.sh
+++ b/tests/waypoint_navigation/simulator_test.sh
@@ -20,7 +20,7 @@ cleanup() {
 trap cleanup ERR
 
 # Launch Stonefish Simulator
-setsid ros2 launch stonefish_sim simulation_nogpu.launch.py task:=orca_no_gpu &
+setsid ros2 launch stonefish_sim simulation.launch.py rendering:=false &
 SIM_PID=$!
 echo "Launched simulator with PID: $SIM_PID"
 


### PR DESCRIPTION
Due to latest update on the simulator repo, the test was failing due to a change in launch command. Fixed. Should be considered to randomize starting and target position, so that the test is more testing.