### PR TITLE
Add pull request trigger to simulator-test workflow

### DIFF
--- a/.github/workflows/simulator-test.yml
+++ b/.github/workflows/simulator-test.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
   schedule:
     - cron: '0 1 * * *' # Runs daily at 01:00 UTC


### PR DESCRIPTION
The simulator test should run on every pull request to make sure it doesnt break anything/introduce problems the other checks wont catch. A requirement for new features should include that the feature is tested in the simulator on pull request. A new test for the new feature must be made first of course.