### PR TITLE
utilize prebuilt stonefish image for simulator test

### DIFF
--- a/.github/workflows/simulator-test.yml
+++ b/.github/workflows/simulator-test.yml
@@ -15,7 +15,7 @@ jobs:
         test_script:
           - "tests/simulator_tests/waypoint_navigation/simulator_test.sh"
           #- "tests/simulator_tests/los_test/simulator_test.sh"
-    uses: vortexntnu/vortex-ci/.github/workflows/reusable-ros2-simulator-test.yml@main
+    uses: vortexntnu/vortex-ci/.github/workflows/reusable-ros2-simulator-test.yml@ci/use-sf-image-in-reusable-workflow
     with:
       vcs_repos_file: "tests/dependencies.repos"
       setup_script: "tests/setup.sh"

--- a/.github/workflows/simulator-test.yml
+++ b/.github/workflows/simulator-test.yml
@@ -15,7 +15,7 @@ jobs:
         test_script:
           - "tests/simulator_tests/waypoint_navigation/simulator_test.sh"
           #- "tests/simulator_tests/los_test/simulator_test.sh"
-    uses: vortexntnu/vortex-ci/.github/workflows/reusable-ros2-simulator-test.yml@ci/use-sf-image-in-reusable-workflow
+    uses: vortexntnu/vortex-ci/.github/workflows/reusable-ros2-simulator-test.yml@main
     with:
       vcs_repos_file: "tests/dependencies.repos"
       setup_script: "tests/setup.sh"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-# ----------------------------- GLOBAL VARIABLES -----------------------------
-STONEFISH_DIR="$HOME/opt/stonefish"
 ROS_WORKSPACE="${WORKSPACE:-$HOME/ros2_ws}"
 LOG_PREFIX="[$(date +%T)]"
 
@@ -15,64 +13,6 @@ log_error() {
     echo -e "$LOG_PREFIX [ERROR] $1" >&2
 }
 
-# ----------------------------- PYTHON DEPENDENCIES -----------------------------
-install_python_dependencies() {
-    log_info "Installing/upgrading Python dependencies..."
-    pip3 install --upgrade pip
-    pip3 install --upgrade 'numpy<1.25' 'scipy<1.12'
-    log_info "Python dependencies installed."
-}
-
-# ----------------------------- C++ DEPENDENCIES -----------------------------
-install_cpp_dependencies() {
-    log_info "Installing required C++ dependencies..."
-    sudo apt-get update -qq
-    sudo apt-get install -y \
-        build-essential \
-        cmake \
-        git \
-        libglm-dev \
-        libsdl2-dev \
-        libfreetype6-dev \
-        ros-humble-rosbag2-storage-mcap
-    log_info "C++ dependencies installed."
-}
-
-install_gcc13_compiler() {
-    log_info "Installing GCC 13 compiler..."
-    sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends software-properties-common
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    sudo apt-get update -qq
-
-    sudo apt-get install -y --no-install-recommends gcc-13 g++-13
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
-}
-
-# ----------------------------- STONEFISH INSTALLATION -----------------------------
-install_stonefish() {
-    if [ -d "$STONEFISH_DIR" ]; then
-        log_info "Stonefish is already installed at $STONEFISH_DIR. Skipping clone."
-    else
-        log_info "Cloning Stonefish repository..."
-        mkdir -p "$STONEFISH_DIR"
-        git clone https://github.com/vortexntnu/stonefish.git "$STONEFISH_DIR"
-        sed -i '30i#include <cstdint>' /github/home/opt/stonefish/Library/include/sensors/Sample.h
-    fi
-
-    log_info "Building Stonefish..."
-    mkdir -p "$STONEFISH_DIR/build"
-    cd "$STONEFISH_DIR/build"
-
-    cmake ..
-    make -j"$(nproc)"
-    sudo make install
-
-    log_info "Stonefish installation complete."
-}
-
-# ----------------------------- BUILD ROS 2 PACKAGES -----------------------------
 build_ros_workspace() {
     log_info "Setting up ROS 2 workspace..."
     cd "$ROS_WORKSPACE"
@@ -87,17 +27,9 @@ build_ros_workspace() {
     . install/setup.bash
 
     log_info "Building remaining ROS 2 packages..."
-    colcon build --packages-ignore stonefish_ros2 --symlink-install
+    colcon build --packages-ignore stonefish_ros2 --symlink-install --executor sequential
 
     log_info "ROS 2 workspace build complete."
 }
 
-# ----------------------------- EXECUTE INSTALLATION -----------------------------
-log_info "Starting manual installation of extra dependencies..."
-install_python_dependencies
-install_cpp_dependencies
-install_gcc13_compiler
-# install_stonefish
 build_ros_workspace
-
-log_info "All dependencies installed successfully."

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -27,7 +27,7 @@ build_ros_workspace() {
     . install/setup.bash
 
     log_info "Building remaining ROS 2 packages..."
-    colcon build --packages-ignore stonefish_ros2 --symlink-install --executor sequential
+    colcon build --packages-ignore stonefish_ros2 --symlink-install
 
     log_info "ROS 2 workspace build complete."
 }

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -97,7 +97,7 @@ log_info "Starting manual installation of extra dependencies..."
 install_python_dependencies
 install_cpp_dependencies
 install_gcc13_compiler
-install_stonefish
+# install_stonefish
 build_ros_workspace
 
 log_info "All dependencies installed successfully."

--- a/tests/simulator_tests/waypoint_navigation/simulator_test.sh
+++ b/tests/simulator_tests/waypoint_navigation/simulator_test.sh
@@ -79,8 +79,8 @@ fi
 
 # Set operation mode
 echo "Turning off killswitch and setting operation mode to autonomous mode"
-ros2 topic pub /orca/killswitch std_msgs/msg/Bool "{data: false}" -1
-ros2 topic pub /orca/operation_mode std_msgs/msg/String "{data: 'autonomous mode'}" -1
+ros2 topic pub /orca/killswitch std_msgs/msg/Bool "{data: false}" -t 5 # Ensure the message arrives
+ros2 topic pub /orca/operation_mode std_msgs/msg/String "{data: 'autonomous mode'}" -t 5 # Ensure the message arrives
 
 # Send waypoint goal
 echo "Sending goal"


### PR DESCRIPTION
- Uses prebuilt sf image to speed up the test setup (removed manual setup, and no fallback in this PR. If the latest docker images suddenly ceases to exist then we just fix it ig 🤷 )
- The rosbag being involved seems to have messed with the receival of the operation_mode topic, leading to DP not activating. Hence the recent fails. This PR publishes the topic 5 times to ensure it is received.