### PR TITLE
drone and namespace separation util

### DIFF
--- a/auv_setup/CMakeLists.txt
+++ b/auv_setup/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.8)
 project(auv_setup)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
 
 install(DIRECTORY
   config

--- a/auv_setup/auv_setup/launch_arg_common.py
+++ b/auv_setup/auv_setup/launch_arg_common.py
@@ -1,0 +1,25 @@
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+
+
+def declare_drone_and_namespace_args(default_drone="orca"):
+    return [
+        DeclareLaunchArgument(
+            "drone",
+            default_value=default_drone,
+            description="Drone model / config name",
+        ),
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="ROS namespace. If empty, uses drone name.",
+        ),
+    ]
+
+
+def resolve_drone_and_namespace(context):
+    drone = LaunchConfiguration("drone").perform(context)
+    namespace = LaunchConfiguration("namespace").perform(context)
+    if namespace == "":
+        namespace = drone
+    return drone, namespace

--- a/auv_setup/config/robots/orca.yaml
+++ b/auv_setup/config/robots/orca.yaml
@@ -139,12 +139,14 @@
       los: "los_guidance"
       landmark_polling: "landmark_polling"
       landmark_convergence: "landmark_convergence"
+      waypoint_manager: "waypoint_manager"
 
     services:
       set_operation_mode: "set_operation_mode"
       set_killswitch: "set_killswitch"
       toggle_killswitch: "toggle_killswitch"
       get_operation_mode: "get_operation_mode"
+      waypoint_addition: "waypoint_addition"
 
     fsm:
       docking:

--- a/auv_setup/config/robots/orca.yaml
+++ b/auv_setup/config/robots/orca.yaml
@@ -133,6 +133,9 @@
         dp: "guidance/dp"
       fsm:
         active_controller: "fsm/active_controller"
+      dvl_twist: "dvl/twist"
+      dvl_altitude: "dvl/altitude"
+      imu: "stim/imu"
 
     action_servers:
       reference_filter: "reference_filter"

--- a/auv_setup/launch/dp.launch.py
+++ b/auv_setup/launch/dp.launch.py
@@ -2,14 +2,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
+
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     filter_file_path = os.path.join(
         get_package_share_directory("reference_filter_dp"),
@@ -32,7 +36,7 @@ def launch_setup(context, *args, **kwargs):
 
     container = ComposableNodeContainer(
         name="dp_container",
-        namespace=drone,
+        namespace=namespace,
         package="rclcpp_components",
         executable="component_container_mt",
         composable_node_descriptions=[
@@ -40,7 +44,7 @@ def launch_setup(context, *args, **kwargs):
                 package="reference_filter_dp",
                 plugin="ReferenceFilterNode",
                 name="reference_filter_node",
-                namespace=drone,
+                namespace=namespace,
                 parameters=[filter_file_path, drone_params],
                 extra_arguments=[{"use_intra_process_comms": True}],
             ),
@@ -48,7 +52,7 @@ def launch_setup(context, *args, **kwargs):
                 package="dp_adapt_backs_controller",
                 plugin="DPAdaptBacksControllerNode",
                 name="dp_adapt_backs_controller_node",
-                namespace=drone,
+                namespace=namespace,
                 parameters=[adapt_params, drone_params],
                 extra_arguments=[{"use_intra_process_comms": True}],
             ),
@@ -62,12 +66,8 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
+        declare_drone_and_namespace_args()
+        + [
             OpaqueFunction(function=launch_setup),
         ]
     )

--- a/auv_setup/launch/thruster.launch.py
+++ b/auv_setup/launch/thruster.launch.py
@@ -2,14 +2,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction, SetEnvironmentVariable
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction, SetEnvironmentVariable
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
+
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     drone_params = os.path.join(
         get_package_share_directory("auv_setup"),
@@ -26,7 +30,7 @@ def launch_setup(context, *args, **kwargs):
 
     container = ComposableNodeContainer(
         name="thruster_container",
-        namespace=drone,
+        namespace=namespace,
         package="rclcpp_components",
         executable="component_container_mt",
         composable_node_descriptions=[
@@ -34,7 +38,7 @@ def launch_setup(context, *args, **kwargs):
                 package="thrust_allocator_auv",
                 plugin="ThrustAllocator",
                 name="thrust_allocator_auv_node",
-                namespace=drone,
+                namespace=namespace,
                 parameters=[drone_params],
                 extra_arguments=[{"use_intra_process_comms": True}],
             ),
@@ -42,7 +46,7 @@ def launch_setup(context, *args, **kwargs):
                 package="thruster_interface_auv",
                 plugin="ThrusterInterfaceAUVNode",
                 name="thruster_interface_auv_node",
-                namespace=drone,
+                namespace=namespace,
                 parameters=[thruster_interface_config, drone_params],
                 extra_arguments=[{"use_intra_process_comms": True}],
             ),
@@ -72,13 +76,7 @@ def generate_launch_description() -> LaunchDescription:
     )
 
     return LaunchDescription(
-        [
-            set_env_var,
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        [set_env_var]
+        + declare_drone_and_namespace_args()
+        + [OpaqueFunction(function=launch_setup)]
     )

--- a/auv_setup/launch/topside.launch.py
+++ b/auv_setup/launch/topside.launch.py
@@ -3,25 +3,28 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
-    DeclareLaunchArgument,
     IncludeLaunchDescription,
     OpaqueFunction,
     SetEnvironmentVariable,
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
     """Set up the topside nodes with drone-specific namespace."""
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     joy_node = Node(
         package="joy",
         executable="joy_node",
         name="joystick_driver",
-        namespace=drone,
+        namespace=namespace,
         output="screen",
         parameters=[
             {"deadzone": 0.15},
@@ -37,7 +40,10 @@ def launch_setup(context, *args, **kwargs):
                 "joystick_interface_auv.launch.py",
             )
         ),
-        launch_arguments={"drone": drone}.items(),
+        launch_arguments={
+            "drone": drone,
+            "namespace": namespace,
+        }.items(),
     )
 
     return [joy_node, joystick_interface_launch]
@@ -60,13 +66,7 @@ def generate_launch_description() -> LaunchDescription:
     )
 
     return LaunchDescription(
-        [
-            set_env_var,
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        [set_env_var]
+        + declare_drone_and_namespace_args()
+        + [OpaqueFunction(function=launch_setup)]
     )

--- a/auv_setup/package.xml
+++ b/auv_setup/package.xml
@@ -8,6 +8,7 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/control/dp_adapt_backs_controller/launch/dp_adapt_backs_controller.launch.py
+++ b/control/dp_adapt_backs_controller/launch/dp_adapt_backs_controller.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     adapt_params = os.path.join(
         get_package_share_directory("dp_adapt_backs_controller"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="dp_adapt_backs_controller",
             executable="dp_adapt_backs_controller_node",
             name="dp_adapt_backs_controller_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[adapt_params, drone_params],
             output="screen",
         )
@@ -37,12 +41,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/control/pid_controller_dp/launch/pid_controller_dp.launch.py
+++ b/control/pid_controller_dp/launch/pid_controller_dp.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     pid_params = os.path.join(
         get_package_share_directory("pid_controller_dp"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="pid_controller_dp",
             executable="pid_controller_node",
             name="pid_controller_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[pid_params, drone_params],
             output="screen",
         )
@@ -37,12 +41,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/control/pid_controller_dp_euler/launch/pid_controller_dp.launch.py
+++ b/control/pid_controller_dp_euler/launch/pid_controller_dp.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     config = os.path.join(
         get_package_share_directory("pid_controller_dp_euler"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="pid_controller_dp_euler",
             executable="pid_controller_node",
             name="pid_controller_euler_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[config, drone_params],
             output="screen",
         )
@@ -37,12 +41,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/control/velocity_controller_lqr/launch/velocity_controller_lqr.launch.py
+++ b/control/velocity_controller_lqr/launch/velocity_controller_lqr.launch.py
@@ -2,14 +2,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
     """Set up the velocity_controller_lqr node with drone-specific config."""
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     parameter_file = os.path.join(
         get_package_share_directory("velocity_controller_lqr"),
@@ -29,7 +33,7 @@ def launch_setup(context, *args, **kwargs):
             package="velocity_controller_lqr",
             executable="velocity_controller_lqr_node.py",
             name="velocity_controller_lqr_node",
-            namespace=drone,
+            namespace=namespace,
             output="screen",
             parameters=[parameter_file, drone_params],
         )
@@ -48,12 +52,5 @@ def generate_launch_description() -> LaunchDescription:
         velocity_controller_lqr node.
     """
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/guidance/los_guidance/launch/los_guidance.launch.py
+++ b/guidance/los_guidance/launch/los_guidance.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     adapt_params = os.path.join(
         get_package_share_directory("los_guidance"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="los_guidance",
             executable="los_guidance_node",
             name="los_guidance_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[drone_params, adapt_params],
             output="screen",
         )
@@ -37,12 +41,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/guidance/reference_filter_dp/launch/reference_filter_dp.launch.py
+++ b/guidance/reference_filter_dp/launch/reference_filter_dp.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     config_file_path = os.path.join(
         get_package_share_directory("reference_filter_dp"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="reference_filter_dp",
             executable="reference_filter_dp_node",
             name="reference_filter_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[config_file_path, drone_params],
             output="screen",
         )
@@ -37,12 +41,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/FSM/docking/launch/YASMIN_viewer.launch.py
+++ b/mission/FSM/docking/launch/YASMIN_viewer.launch.py
@@ -1,20 +1,24 @@
 import launch.actions
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
     """Set up the yasmin viewer node."""
-    drone = LaunchConfiguration("drone").perform(context)
+    _drone, namespace = resolve_drone_and_namespace(context)
 
     return [
         Node(
             package="yasmin_viewer",
             executable="yasmin_viewer_node",
             name="yasmin_viewer",
-            namespace=drone,
+            namespace=namespace,
             on_exit=launch.actions.LogInfo(msg="Yasmin_viewer exited"),
         )
     ]
@@ -23,12 +27,5 @@ def launch_setup(context, *args, **kwargs):
 def generate_launch_description() -> LaunchDescription:
     """Launch file to launch the yasmin viewer."""
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/FSM/docking/launch/docking.launch.py
+++ b/mission/FSM/docking/launch/docking.launch.py
@@ -3,14 +3,18 @@ import os
 import launch.actions
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
     """Launch all nodes necessary for docking fsm."""
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     drone_params = os.path.join(
         get_package_share_directory("auv_setup"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
     docking_launch = Node(
         package="docking",
         executable="docking",
-        namespace=drone,
+        namespace=namespace,
         parameters=[drone_params, pose_config],
         on_exit=launch.actions.LogInfo(msg="Docking exited"),
         output="screen",
@@ -38,7 +42,7 @@ def launch_setup(context, *args, **kwargs):
         package="publish_docking_state",
         executable="publish_docking_state",
         name="publish_docking_state",
-        namespace=drone,
+        namespace=namespace,
         parameters=[drone_params],
         on_exit=launch.actions.LogInfo(msg="Publish docking state node exited"),
         output="screen",
@@ -50,12 +54,5 @@ def launch_setup(context, *args, **kwargs):
 def generate_launch_description() -> LaunchDescription:
     """Launch file to launch all nodes necessary for docking fsm."""
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/joystick_interface_auv/launch/joystick_interface_auv.launch.py
+++ b/mission/joystick_interface_auv/launch/joystick_interface_auv.launch.py
@@ -2,14 +2,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
     """Set up the joystick_interface_auv node with drone-specific config."""
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     joystick_params = os.path.join(
         get_package_share_directory("joystick_interface_auv"),
@@ -29,7 +33,7 @@ def launch_setup(context, *args, **kwargs):
             package="joystick_interface_auv",
             executable="joystick_interface_auv_node.py",
             name="joystick_interface_auv",
-            namespace=drone,
+            namespace=namespace,
             output="screen",
             parameters=[joystick_params, drone_params],
         )
@@ -49,12 +53,5 @@ def generate_launch_description() -> LaunchDescription:
 
     """
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/keyboard_joy/launch/keyboard_joy_node.launch.py
+++ b/mission/keyboard_joy/launch/keyboard_joy_node.launch.py
@@ -6,9 +6,14 @@ from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
+
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     drone_params = os.path.join(
         get_package_share_directory("auv_setup"),
@@ -22,7 +27,7 @@ def launch_setup(context, *args, **kwargs):
             package="keyboard_joy",
             executable="keyboard_joy_node",
             name="keyboard_joy",
-            namespace=drone,
+            namespace=namespace,
             output="screen",
             parameters=[
                 {"config": LaunchConfiguration("config").perform(context)},
@@ -46,11 +51,7 @@ def generate_launch_description():
                 default_value=keyboard_config,
                 description="Path to key mappings YAML file",
             ),
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
         ]
+        + declare_drone_and_namespace_args()
+        + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/landmark_server/launch/landmark_server.launch.py
+++ b/mission/landmark_server/launch/landmark_server.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     landmark_config = os.path.join(
         get_package_share_directory("landmark_server"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="landmark_server",
             executable="landmark_server_node",
             name="landmark_server_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[
                 landmark_config,
                 drone_params,
@@ -43,12 +47,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/operation_mode_manager/launch/operation_mode_manager.launch.py
+++ b/mission/operation_mode_manager/launch/operation_mode_manager.launch.py
@@ -2,14 +2,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
     """Set up the operation_mode_manager node with drone-specific config."""
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     drone_params = os.path.join(
         get_package_share_directory("auv_setup"),
@@ -29,7 +33,7 @@ def launch_setup(context, *args, **kwargs):
             package="operation_mode_manager",
             executable="operation_mode_manager_cpp",
             name="operation_mode_manager",
-            namespace=drone,
+            namespace=namespace,
             output="screen",
             parameters=[drone_params, operation_mode_params],
         )
@@ -48,12 +52,5 @@ def generate_launch_description() -> LaunchDescription:
 
     """
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/waypoint_manager/launch/waypoint_manager.launch.py
+++ b/mission/waypoint_manager/launch/waypoint_manager.launch.py
@@ -1,19 +1,33 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
+
+    drone_params = os.path.join(
+        get_package_share_directory("auv_setup"),
+        "config",
+        "robots",
+        f"{drone}.yaml",
+    )
 
     return [
         Node(
             package="waypoint_manager",
             executable="waypoint_manager_node",
             name="waypoint_manager_node",
-            namespace=drone,
-            parameters=[],
+            namespace=namespace,
+            parameters=[drone_params],
             output="screen",
         )
     ]
@@ -21,12 +35,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description():
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/mission/waypoint_manager/src/waypoint_manager_ros.cpp
+++ b/mission/waypoint_manager/src/waypoint_manager_ros.cpp
@@ -51,8 +51,10 @@ void WaypointManagerNode::set_reference_action_client() {
 }
 
 void WaypointManagerNode::set_waypoint_action_server() {
+    std::string action_name =
+        this->declare_parameter<std::string>("action_servers.waypoint_manager");
     waypoint_action_server_ = rclcpp_action::create_server<WaypointManager>(
-        this, "waypoint_manager",
+        this, action_name,
 
         [this](auto goal_id, auto goal) {
             return handle_waypoint_goal(goal_id, goal);
@@ -66,9 +68,11 @@ void WaypointManagerNode::set_waypoint_action_server() {
 }
 
 void WaypointManagerNode::set_waypoint_service_server() {
+    std::string service_name =
+        this->declare_parameter<std::string>("services.waypoint_addition");
     waypoint_service_server_ =
         this->create_service<vortex_msgs::srv::SendWaypoints>(
-            "waypoint_addition",
+            service_name,
             std::bind(
                 &WaypointManagerNode::handle_send_waypoints_service_request,
                 this, std::placeholders::_1, std::placeholders::_2));

--- a/mission/waypoint_manager/test/test_service.py
+++ b/mission/waypoint_manager/test/test_service.py
@@ -8,24 +8,36 @@ import launch_testing
 import launch_testing.actions
 import rclpy
 from ament_index_python.packages import get_package_share_directory
+from launch.actions import OpaqueFunction
 from rclpy.action import ActionClient
 from vortex_msgs.action import WaypointManager
 from vortex_msgs.msg import Waypoint
 from vortex_msgs.srv import SendWaypoints
 
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
-def generate_test_description():
+NAMESPACE = 'orca'  # updated by launch_setup
+
+
+def launch_setup(context, *args, **kwargs):
+    global NAMESPACE
+    drone, namespace = resolve_drone_and_namespace(context)
+    NAMESPACE = namespace
+
     rf_pkg_share = get_package_share_directory('reference_filter_dp')
     rf_config = os.path.join(rf_pkg_share, 'config', 'reference_filter_params.yaml')
 
     auv_setup_share = get_package_share_directory('auv_setup')
-    orca_config = os.path.join(auv_setup_share, 'config', 'robots', 'orca.yaml')
+    drone_config = os.path.join(auv_setup_share, 'config', 'robots', f'{drone}.yaml')
 
     wm_node = launch_ros.actions.Node(
         package='waypoint_manager',
         executable='waypoint_manager_node',
         name='waypoint_manager_node',
-        namespace='orca',
+        namespace=namespace,
         output='screen',
     )
 
@@ -33,17 +45,17 @@ def generate_test_description():
         package='reference_filter_dp',
         executable='reference_filter_dp_node',
         name='reference_filter_node',
-        namespace='orca',
-        parameters=[rf_config, orca_config],
+        namespace=namespace,
+        parameters=[rf_config, drone_config],
         output='screen',
     )
 
+    return [wm_node, rf_node, launch_testing.actions.ReadyToTest()]
+
+
+def generate_test_description():
     return launch.LaunchDescription(
-        [
-            wm_node,
-            rf_node,
-            launch_testing.actions.ReadyToTest(),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )
 
 
@@ -72,7 +84,9 @@ class TestWaypointManagerService(unittest.TestCase):
         take_priority=False,
         timeout=5.0,
     ):
-        client = self.node.create_client(SendWaypoints, '/orca/waypoint_addition')
+        client = self.node.create_client(
+            SendWaypoints, f'/{NAMESPACE}/waypoint_addition'
+        )
         assert client.wait_for_service(timeout_sec=5.0), (
             'SendWaypoints service not available'
         )
@@ -103,7 +117,7 @@ class TestWaypointManagerService(unittest.TestCase):
     def test_priority_blocks_non_priority_calls(self):
         # Send a persistent action goal so the waypoint manager is in persistent mode
         action_client = ActionClient(
-            self.node, WaypointManager, '/orca/waypoint_manager'
+            self.node, WaypointManager, f'/{NAMESPACE}/waypoint_manager'
         )
         assert action_client.wait_for_server(timeout_sec=10.0), (
             'WaypointManager action server not available'

--- a/mission/waypoint_manager/test/test_service.py
+++ b/mission/waypoint_manager/test/test_service.py
@@ -39,6 +39,7 @@ def launch_setup(context, *args, **kwargs):
         executable="waypoint_manager_node",
         name="waypoint_manager_node",
         namespace=namespace,
+        parameters=[drone_config],
         output="screen",
     )
 

--- a/mission/waypoint_manager/test/test_service.py
+++ b/mission/waypoint_manager/test/test_service.py
@@ -3,12 +3,13 @@ import unittest
 import uuid
 
 import launch
+import launch.actions
 import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import rclpy
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import OpaqueFunction
+from launch.actions import OpaqueFunction, TimerAction
 from rclpy.action import ActionClient
 from vortex_msgs.action import WaypointManager
 from vortex_msgs.msg import Waypoint
@@ -19,7 +20,7 @@ from auv_setup.launch_arg_common import (
     resolve_drone_and_namespace,
 )
 
-NAMESPACE = 'orca'  # updated by launch_setup
+NAMESPACE = "orca"
 
 
 def launch_setup(context, *args, **kwargs):
@@ -27,35 +28,42 @@ def launch_setup(context, *args, **kwargs):
     drone, namespace = resolve_drone_and_namespace(context)
     NAMESPACE = namespace
 
-    rf_pkg_share = get_package_share_directory('reference_filter_dp')
-    rf_config = os.path.join(rf_pkg_share, 'config', 'reference_filter_params.yaml')
+    rf_pkg_share = get_package_share_directory("reference_filter_dp")
+    rf_config = os.path.join(rf_pkg_share, "config", "reference_filter_params.yaml")
 
-    auv_setup_share = get_package_share_directory('auv_setup')
-    drone_config = os.path.join(auv_setup_share, 'config', 'robots', f'{drone}.yaml')
+    auv_setup_share = get_package_share_directory("auv_setup")
+    drone_config = os.path.join(auv_setup_share, "config", "robots", f"{drone}.yaml")
 
     wm_node = launch_ros.actions.Node(
-        package='waypoint_manager',
-        executable='waypoint_manager_node',
-        name='waypoint_manager_node',
+        package="waypoint_manager",
+        executable="waypoint_manager_node",
+        name="waypoint_manager_node",
         namespace=namespace,
-        output='screen',
+        output="screen",
     )
 
     rf_node = launch_ros.actions.Node(
-        package='reference_filter_dp',
-        executable='reference_filter_dp_node',
-        name='reference_filter_node',
+        package="reference_filter_dp",
+        executable="reference_filter_dp_node",
+        name="reference_filter_node",
         namespace=namespace,
         parameters=[rf_config, drone_config],
-        output='screen',
+        output="screen",
     )
 
-    return [wm_node, rf_node, launch_testing.actions.ReadyToTest()]
+    return [wm_node, rf_node]
 
 
 def generate_test_description():
     return launch.LaunchDescription(
-        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
+        declare_drone_and_namespace_args()
+        + [
+            OpaqueFunction(function=launch_setup),
+            TimerAction(
+                period=1.0,
+                actions=[launch_testing.actions.ReadyToTest()],
+            ),
+        ]
     )
 
 

--- a/mission/waypoint_manager/test/test_single_waypoint.py
+++ b/mission/waypoint_manager/test/test_single_waypoint.py
@@ -41,6 +41,7 @@ def launch_setup(context, *args, **kwargs):
         executable="waypoint_manager_node",
         name="waypoint_manager_node",
         namespace=namespace,
+        parameters=[drone_config],
         output="screen",
     )
 

--- a/mission/waypoint_manager/test/test_single_waypoint.py
+++ b/mission/waypoint_manager/test/test_single_waypoint.py
@@ -10,24 +10,36 @@ import launch_testing.actions
 import rclpy
 from ament_index_python.packages import get_package_share_directory
 from geometry_msgs.msg import PoseWithCovarianceStamped
+from launch.actions import OpaqueFunction
 from rclpy.action import ActionClient
 from rclpy.qos import qos_profile_sensor_data
 from vortex_msgs.action import WaypointManager
 from vortex_msgs.msg import Waypoint
 
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
-def generate_test_description():
+NAMESPACE = 'orca'  # updated by launch_setup
+
+
+def launch_setup(context, *args, **kwargs):
+    global NAMESPACE
+    drone, namespace = resolve_drone_and_namespace(context)
+    NAMESPACE = namespace
+
     rf_pkg_share = get_package_share_directory('reference_filter_dp')
     rf_config = os.path.join(rf_pkg_share, 'config', 'reference_filter_params.yaml')
 
     auv_setup_share = get_package_share_directory('auv_setup')
-    orca_config = os.path.join(auv_setup_share, 'config', 'robots', 'orca.yaml')
+    drone_config = os.path.join(auv_setup_share, 'config', 'robots', f'{drone}.yaml')
 
     wm_node = launch_ros.actions.Node(
         package='waypoint_manager',
         executable='waypoint_manager_node',
         name='waypoint_manager_node',
-        namespace='orca',
+        namespace=namespace,
         output='screen',
     )
 
@@ -35,17 +47,17 @@ def generate_test_description():
         package='reference_filter_dp',
         executable='reference_filter_dp_node',
         name='reference_filter_node',
-        namespace='orca',
-        parameters=[rf_config, orca_config],
+        namespace=namespace,
+        parameters=[rf_config, drone_config],
         output='screen',
     )
 
+    return [wm_node, rf_node, launch_testing.actions.ReadyToTest()]
+
+
+def generate_test_description():
     return launch.LaunchDescription(
-        [
-            wm_node,
-            rf_node,
-            launch_testing.actions.ReadyToTest(),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )
 
 
@@ -69,7 +81,7 @@ class TestWaypointManagerAcceptsGoal(unittest.TestCase):
     def _publish_fake_pose(self, x, y, z, duration_sec=5.0, rate_hz=10.0):
         pub = self.node.create_publisher(
             PoseWithCovarianceStamped,
-            '/orca/pose',
+            f'/{NAMESPACE}/pose',
             qos_profile_sensor_data,
         )
 
@@ -100,7 +112,9 @@ class TestWaypointManagerAcceptsGoal(unittest.TestCase):
         self.node.destroy_publisher(pub)
 
     def test_accepts_and_executes_goal(self):
-        client = ActionClient(self.node, WaypointManager, '/orca/waypoint_manager')
+        client = ActionClient(
+            self.node, WaypointManager, f'/{NAMESPACE}/waypoint_manager'
+        )
 
         assert client.wait_for_server(timeout_sec=10.0), (
             'WaypointManager action server not available'

--- a/mission/waypoint_manager/test/test_single_waypoint.py
+++ b/mission/waypoint_manager/test/test_single_waypoint.py
@@ -4,13 +4,14 @@ import unittest
 import uuid
 
 import launch
+import launch.actions
 import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import rclpy
 from ament_index_python.packages import get_package_share_directory
 from geometry_msgs.msg import PoseWithCovarianceStamped
-from launch.actions import OpaqueFunction
+from launch.actions import OpaqueFunction, TimerAction
 from rclpy.action import ActionClient
 from rclpy.qos import qos_profile_sensor_data
 from vortex_msgs.action import WaypointManager
@@ -21,7 +22,7 @@ from auv_setup.launch_arg_common import (
     resolve_drone_and_namespace,
 )
 
-NAMESPACE = 'orca'  # updated by launch_setup
+NAMESPACE = "orca"
 
 
 def launch_setup(context, *args, **kwargs):
@@ -29,35 +30,42 @@ def launch_setup(context, *args, **kwargs):
     drone, namespace = resolve_drone_and_namespace(context)
     NAMESPACE = namespace
 
-    rf_pkg_share = get_package_share_directory('reference_filter_dp')
-    rf_config = os.path.join(rf_pkg_share, 'config', 'reference_filter_params.yaml')
+    rf_pkg_share = get_package_share_directory("reference_filter_dp")
+    rf_config = os.path.join(rf_pkg_share, "config", "reference_filter_params.yaml")
 
-    auv_setup_share = get_package_share_directory('auv_setup')
-    drone_config = os.path.join(auv_setup_share, 'config', 'robots', f'{drone}.yaml')
+    auv_setup_share = get_package_share_directory("auv_setup")
+    drone_config = os.path.join(auv_setup_share, "config", "robots", f"{drone}.yaml")
 
     wm_node = launch_ros.actions.Node(
-        package='waypoint_manager',
-        executable='waypoint_manager_node',
-        name='waypoint_manager_node',
+        package="waypoint_manager",
+        executable="waypoint_manager_node",
+        name="waypoint_manager_node",
         namespace=namespace,
-        output='screen',
+        output="screen",
     )
 
     rf_node = launch_ros.actions.Node(
-        package='reference_filter_dp',
-        executable='reference_filter_dp_node',
-        name='reference_filter_node',
+        package="reference_filter_dp",
+        executable="reference_filter_dp_node",
+        name="reference_filter_node",
         namespace=namespace,
         parameters=[rf_config, drone_config],
-        output='screen',
+        output="screen",
     )
 
-    return [wm_node, rf_node, launch_testing.actions.ReadyToTest()]
+    return [wm_node, rf_node]
 
 
 def generate_test_description():
     return launch.LaunchDescription(
-        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
+        declare_drone_and_namespace_args()
+        + [
+            OpaqueFunction(function=launch_setup),
+            TimerAction(
+                period=1.0,
+                actions=[launch_testing.actions.ReadyToTest()],
+            ),
+        ]
     )
 
 

--- a/motion/thrust_allocator_auv/launch/thrust_allocator_auv.launch.py
+++ b/motion/thrust_allocator_auv/launch/thrust_allocator_auv.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     config_file = os.path.join(
         get_package_share_directory("auv_setup"),
@@ -22,7 +26,7 @@ def launch_setup(context, *args, **kwargs):
             package="thrust_allocator_auv",
             executable="thrust_allocator_auv_node",
             name="thrust_allocator_auv_node",
-            namespace=drone,
+            namespace=namespace,
             parameters=[config_file],
             output="screen",
         )
@@ -31,12 +35,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )

--- a/motion/thruster_interface_auv/launch/thruster_interface_auv.launch.py
+++ b/motion/thruster_interface_auv/launch/thruster_interface_auv.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration
+from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
+
+from auv_setup.launch_arg_common import (
+    declare_drone_and_namespace_args,
+    resolve_drone_and_namespace,
+)
 
 
 def launch_setup(context, *args, **kwargs):
-    drone = LaunchConfiguration("drone").perform(context)
+    drone, namespace = resolve_drone_and_namespace(context)
 
     drone_params = os.path.join(
         get_package_share_directory("auv_setup"),
@@ -28,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
             package="thruster_interface_auv",
             executable="thruster_interface_auv_node",
             name="thruster_interface_auv_node",
-            namespace=drone,
+            namespace=namespace,
             output="screen",
             parameters=[drone_params, thruster_config],
         )
@@ -37,12 +41,5 @@ def launch_setup(context, *args, **kwargs):
 
 def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "drone",
-                default_value="orca",
-                description="Drone name / namespace",
-            ),
-            OpaqueFunction(function=launch_setup),
-        ]
+        declare_drone_and_namespace_args() + [OpaqueFunction(function=launch_setup)]
     )


### PR DESCRIPTION
Launch helper to declare drone and namespace arg.
Made auv_setup to ament_python package to use helper in other packages.


Renamed launch file to be drone agnostic: orca.launch.py -> thruster.launch.py
Waypoint manager now uses interfaces from {drone}.yaml

This separation of drone and namespace can allow us to have multiple drones running in the simulator at the same time with different namespaces
