### PR TITLE
fix topic discovery in lqr node test

### DIFF
--- a/tests/ros_node_tests/lqr_autopilot_node_test.sh
+++ b/tests/ros_node_tests/lqr_autopilot_node_test.sh
@@ -41,7 +41,7 @@ ros2 service call /orca/set_operation_mode vortex_msgs/srv/SetOperationMode "{re
 sleep 2
 # Check if controller correctly publishes tau
 echo "Waiting for wrench data..."
-timeout 20s ros2 topic echo /orca/wrench_input --once
+timeout 20s ros2 topic echo /orca/wrench_input --once --qos-reliability best_effort
 echo "Got wrench data"
 
 # Terminate processes


### PR DESCRIPTION
The publisher uses BEST_EFFORT QoS (via sensor_data_profile), but ros2 topic echo defaults to RELIABLE when it can't auto-detect the publisher's QoS.  The test is flaky because it depends on whether DDS discovery completes before ros2 topic echo sets up its subscription. Adding --qos-reliability best_effort ensures the subscriber always uses a compatible QoS regardless of discovery timing.