### PR TITLE
Refactor/reference filter dp

### DIFF
--- a/guidance/reference_filter_dp/CMakeLists.txt
+++ b/guidance/reference_filter_dp/CMakeLists.txt
@@ -28,6 +28,8 @@ set(CORE_LIB_NAME "${PROJECT_NAME}")
 
 add_library(${CORE_LIB_NAME} SHARED
   src/lib/reference_filter.cpp
+  src/lib/waypoint_utils.cpp
+  src/lib/waypoint_follower.cpp
 )
 
 target_include_directories(${CORE_LIB_NAME}
@@ -38,6 +40,7 @@ target_include_directories(${CORE_LIB_NAME}
 
 ament_target_dependencies(${CORE_LIB_NAME}
   Eigen3
+  vortex_utils
 )
 
 set(COMPONENT_LIB_NAME "${PROJECT_NAME}_component")
@@ -91,6 +94,7 @@ install(DIRECTORY
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   Eigen3
+  vortex_utils
 )
 ament_export_include_directories(include)
 ament_export_libraries(${CORE_LIB_NAME})

--- a/guidance/reference_filter_dp/CMakeLists.txt
+++ b/guidance/reference_filter_dp/CMakeLists.txt
@@ -24,19 +24,34 @@ find_package(fmt REQUIRED)
 
 include_directories(include)
 
-set(LIB_NAME "${PROJECT_NAME}_component")
+set(CORE_LIB_NAME "${PROJECT_NAME}")
 
-add_library(${LIB_NAME} SHARED
-  src/reference_filter.cpp
-  src/reference_filter_ros.cpp)
+add_library(${CORE_LIB_NAME} SHARED
+  src/lib/reference_filter.cpp
+)
 
-ament_target_dependencies(${LIB_NAME} PUBLIC
+target_include_directories(${CORE_LIB_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(${CORE_LIB_NAME}
+  Eigen3
+)
+
+set(COMPONENT_LIB_NAME "${PROJECT_NAME}_component")
+
+add_library(${COMPONENT_LIB_NAME} SHARED
+  src/ros/reference_filter_ros.cpp
+)
+
+ament_target_dependencies(${COMPONENT_LIB_NAME}
   rclcpp
   rclcpp_components
   rclcpp_action
   geometry_msgs
   nav_msgs
-  Eigen3
   vortex_msgs
   vortex_utils
   vortex_utils_ros
@@ -44,16 +59,19 @@ ament_target_dependencies(${LIB_NAME} PUBLIC
   fmt
 )
 
+target_link_libraries(${COMPONENT_LIB_NAME} ${CORE_LIB_NAME})
+
 rclcpp_components_register_node(
-  ${LIB_NAME}
+  ${COMPONENT_LIB_NAME}
   PLUGIN "ReferenceFilterNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
-ament_export_targets(export_${LIB_NAME})
-
-install(TARGETS ${LIB_NAME}
-  EXPORT export_${LIB_NAME}
+install(
+  TARGETS
+    ${CORE_LIB_NAME}
+    ${COMPONENT_LIB_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -69,6 +87,13 @@ install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME}/
 )
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  Eigen3
+)
+ament_export_include_directories(include)
+ament_export_libraries(${CORE_LIB_NAME})
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/guidance/reference_filter_dp/README.md
+++ b/guidance/reference_filter_dp/README.md
@@ -33,10 +33,28 @@ The state at the next time step is calculated using forward Euler integration
 x_{i+1} = x_i + \dot{x}_i * dt
 ```
 
+## Waypoint modes
+
+Each waypoint has a mode that determines which degrees of freedom are controlled by the reference filter. The mode also determines how convergence is measured.
+
+| Mode | Controlled DOFs | Convergence metric |
+|---|---|---|
+| `FULL_POSE` | All 6 DOF (position + orientation) | Euclidean norm of position and angle errors |
+| `ONLY_POSITION` | x, y, z (orientation holds current value) | Euclidean norm of position error |
+| `FORWARD_HEADING` | x, y, z + yaw toward target (roll/pitch = 0) | Euclidean norm of position error and yaw error |
+| `ONLY_ORIENTATION` | roll, pitch, yaw (position holds current value) | Euclidean norm of angle errors |
+
+For all modes, convergence is reached when the error metric drops below the `convergence_threshold` specified in the action goal.
+
 ## Action Server
-The action server is responsible for handling goal requests and publishing guidance commands. The server will always prioritize new goal request, and will abort ongoing request when getting a new request. The action definition can be found [here](https://github.com/vortexntnu/vortex-msgs/blob/main/action/ReferenceFilterWaypoint.action).
+
+The action server is responsible for handling goal requests and publishing guidance commands. The server will always prioritize new goal requests, and will abort ongoing requests when getting a new request. The action definition can be found [here](https://github.com/vortexntnu/vortex-msgs/blob/main/action/ReferenceFilterWaypoint.action).
 
 - Action name: /reference_filter
 - Goal type: PoseStamped
 - Result type: bool
 - Guidance topic: /dp/reference
+
+### Overwriting the reference during an action
+
+While an action is executing, the reference goal can be updated at any time by publishing a `geometry_msgs/msg/PoseStamped` to the reference pose topic. This allows external nodes to adjust the target pose mid-action without canceling and resending the goal. The convergence check will use the updated reference, so the action completes when the vehicle reaches the latest reference.

--- a/guidance/reference_filter_dp/config/reference_filter_params.yaml
+++ b/guidance/reference_filter_dp/config/reference_filter_params.yaml
@@ -2,3 +2,4 @@
   ros__parameters:
     zeta: [1., 1., 1., 1., 1., 1.]
     omega: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+    time_step_ms: 10

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/eigen_typedefs.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/eigen_typedefs.hpp
@@ -3,8 +3,8 @@
  * @brief Contains Eigen typedefs used in this package.
  */
 
-#ifndef REFERENCE_FILTER_DP__EIGEN_TYPEDEFS_HPP_
-#define REFERENCE_FILTER_DP__EIGEN_TYPEDEFS_HPP_
+#ifndef REFERENCE_FILTER_DP__LIB__EIGEN_TYPEDEFS_HPP_
+#define REFERENCE_FILTER_DP__LIB__EIGEN_TYPEDEFS_HPP_
 
 #include <eigen3/Eigen/Dense>
 
@@ -18,4 +18,4 @@ typedef Eigen::Matrix<double, 18, 1> Vector18d;
 
 }  // namespace Eigen
 
-#endif  // REFERENCE_FILTER_DP__EIGEN_TYPEDEFS_HPP_
+#endif  // REFERENCE_FILTER_DP__LIB__EIGEN_TYPEDEFS_HPP_

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/reference_filter.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/reference_filter.hpp
@@ -10,6 +10,12 @@ struct ReferenceFilterParams {
     Eigen::Vector6d zeta = Eigen::Vector6d::Zero();
 };
 
+/**
+ * @brief Stateless third-order reference filter.
+ *
+ * Computes the state derivative x_dot = Ad * x + Bd * r, where the state
+ * x = [eta, eta_dot, eta_ddot] is 18-dimensional and r is the 6D reference.
+ */
 class ReferenceFilter {
    public:
     explicit ReferenceFilter(const ReferenceFilterParams& params);

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/reference_filter.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/reference_filter.hpp
@@ -1,7 +1,7 @@
-#ifndef REFERENCE_FILTER_DP__REFERENCE_FILTER_HPP_
-#define REFERENCE_FILTER_DP__REFERENCE_FILTER_HPP_
+#ifndef REFERENCE_FILTER_DP__LIB__REFERENCE_FILTER_HPP_
+#define REFERENCE_FILTER_DP__LIB__REFERENCE_FILTER_HPP_
 
-#include "reference_filter_dp/eigen_typedefs.hpp"
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
 
 namespace vortex::guidance {
 
@@ -41,4 +41,4 @@ class ReferenceFilter {
 
 }  // namespace vortex::guidance
 
-#endif  // REFERENCE_FILTER_DP__REFERENCE_FILTER_HPP_
+#endif  // REFERENCE_FILTER_DP__LIB__REFERENCE_FILTER_HPP_

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -27,7 +27,7 @@ class WaypointFollower {
 
     StepResult step(const Eigen::Vector6d& measured_pose);
 
-    void set_reference(const Eigen::Vector6d& r, WaypointMode mode);
+    void set_reference(const PoseEuler& reference_goal_pose, WaypointMode mode);
 
     const Eigen::Vector18d& state() const;
     const Eigen::Vector6d& reference() const;
@@ -40,7 +40,7 @@ class WaypointFollower {
     ReferenceFilter filter_;
     double dt_seconds_;
     Eigen::Vector18d x_ = Eigen::Vector18d::Zero();
-    Eigen::Vector6d r_ = Eigen::Vector6d::Zero();
+    Eigen::Vector6d reference_goal_ = Eigen::Vector6d::Zero();
     Waypoint waypoint_{};
     double convergence_threshold_{0.1};
 };

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -41,7 +41,7 @@ class WaypointFollower {
     mutable std::mutex mutex_;
     ReferenceFilter filter_;
     double dt_seconds_{0.01};
-    Eigen::Vector18d x_ = Eigen::Vector18d::Zero();
+    Eigen::Vector18d state_ = Eigen::Vector18d::Zero();
     Eigen::Vector6d reference_goal_ = Eigen::Vector6d::Zero();
     WaypointMode waypoint_mode_{WaypointMode::FULL_POSE};
     double convergence_threshold_{0.1};

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -11,27 +11,60 @@ namespace vortex::guidance {
 using vortex::utils::types::PoseEuler;
 using vortex::utils::types::Twist;
 
+/**
+ * @brief Result of a single step of the waypoint follower.
+ */
 struct StepResult {
-    Eigen::Vector18d reference_state;
-    bool target_reached;
+    Eigen::Vector18d
+        reference_state;  ///< Filter state: [pose, pose_dot, pose_ddot].
+    bool target_reached;  ///< True if measured pose has converged.
 };
 
+/**
+ * @brief Manages reference filter state and waypoint following logic.
+ *
+ * Thread-safe: all public methods acquire a mutex.
+ */
 class WaypointFollower {
    public:
     WaypointFollower(const ReferenceFilterParams& params, double dt_seconds);
 
+    /**
+     * @brief Initialize the follower with the current vehicle state and target.
+     * @param pose Current vehicle pose.
+     * @param twist Current vehicle twist (body frame).
+     * @param waypoint Target waypoint with mode.
+     * @param convergence_threshold Max error norm to consider target reached.
+     */
     void start(const PoseEuler& pose,
                const Twist& twist,
                const Waypoint& waypoint,
                double convergence_threshold);
 
+    /**
+     * @brief Advance the filter by one time step.
+     * @param measured_pose Current measured pose for convergence checking.
+     * @return StepResult with the updated filter state and convergence status.
+     */
     StepResult step(const Eigen::Vector6d& measured_pose);
 
+    /**
+     * @brief Update the reference goal pose mid-sequence.
+     * @param reference_goal_pose The new reference pose.
+     */
     void set_reference(const PoseEuler& reference_goal_pose);
 
+    /**
+     * @brief Snap the position component of the filter state to the reference.
+     *
+     * Useful after convergence to eliminate any remaining steady-state offset
+     */
     void snap_state_to_reference();
 
+    /// @brief Get the current 18D filter state.
     Eigen::Vector18d state() const;
+
+    /// @brief Get the current 6D reference goal pose.
     Eigen::Vector6d reference() const;
 
    private:

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -12,9 +12,8 @@ using vortex::utils::types::PoseEuler;
 using vortex::utils::types::Twist;
 
 struct StepResult {
-    Eigen::Vector18d state;
-    Eigen::Vector6d reference;
-    bool converged;
+    Eigen::Vector18d reference_state;
+    bool target_reached;
 };
 
 class WaypointFollower {
@@ -30,9 +29,10 @@ class WaypointFollower {
 
     void set_reference(const PoseEuler& reference_goal_pose);
 
+    void snap_state_to_reference();
+
     Eigen::Vector18d state() const;
     Eigen::Vector6d reference() const;
-    void snap_state_to_reference();
 
    private:
     Eigen::Vector18d compute_initial_state(const PoseEuler& pose,

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -1,6 +1,7 @@
 #ifndef REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_
 #define REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_
 
+#include <mutex>
 #include <vortex/utils/types.hpp>
 #include "reference_filter_dp/lib/reference_filter.hpp"
 #include "reference_filter_dp/lib/waypoint_types.hpp"
@@ -29,19 +30,20 @@ class WaypointFollower {
 
     void set_reference(const PoseEuler& reference_goal_pose, WaypointMode mode);
 
-    const Eigen::Vector18d& state() const;
-    const Eigen::Vector6d& reference() const;
+    Eigen::Vector18d state() const;
+    Eigen::Vector6d reference() const;
     void snap_state_to_reference();
 
    private:
     Eigen::Vector18d compute_initial_state(const PoseEuler& pose,
                                            const Twist& twist);
 
+    mutable std::mutex mutex_;
     ReferenceFilter filter_;
-    double dt_seconds_;
+    double dt_seconds_{0.01};
     Eigen::Vector18d x_ = Eigen::Vector18d::Zero();
     Eigen::Vector6d reference_goal_ = Eigen::Vector6d::Zero();
-    Waypoint waypoint_{};
+    WaypointMode waypoint_{WaypointMode::FULL_POSE};
     double convergence_threshold_{0.1};
 };
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -1,0 +1,42 @@
+#ifndef REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_
+#define REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_
+
+#include "reference_filter_dp/lib/reference_filter.hpp"
+#include "reference_filter_dp/lib/waypoint_types.hpp"
+
+namespace vortex::guidance {
+
+struct StepResult {
+    Eigen::Vector18d state;
+    Eigen::Vector6d reference;
+    bool converged;
+};
+
+class WaypointFollower {
+   public:
+    WaypointFollower(const ReferenceFilterParams& params, double dt_seconds);
+
+    void start(const Eigen::Vector18d& initial_state,
+               const Waypoint& waypoint,
+               double convergence_threshold);
+
+    StepResult step(const Eigen::Vector6d& measured_pose);
+
+    void set_reference(const Eigen::Vector6d& r, WaypointMode mode);
+
+    const Eigen::Vector18d& state() const;
+    const Eigen::Vector6d& reference() const;
+    void snap_state_to_reference();
+
+   private:
+    ReferenceFilter filter_;
+    double dt_seconds_;
+    Eigen::Vector18d x_ = Eigen::Vector18d::Zero();
+    Eigen::Vector6d r_ = Eigen::Vector6d::Zero();
+    Waypoint waypoint_{};
+    double convergence_threshold_{0.1};
+};
+
+}  // namespace vortex::guidance
+
+#endif  // REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -28,7 +28,7 @@ class WaypointFollower {
 
     StepResult step(const Eigen::Vector6d& measured_pose);
 
-    void set_reference(const PoseEuler& reference_goal_pose, WaypointMode mode);
+    void set_reference(const PoseEuler& reference_goal_pose);
 
     Eigen::Vector18d state() const;
     Eigen::Vector6d reference() const;
@@ -43,7 +43,7 @@ class WaypointFollower {
     double dt_seconds_{0.01};
     Eigen::Vector18d x_ = Eigen::Vector18d::Zero();
     Eigen::Vector6d reference_goal_ = Eigen::Vector6d::Zero();
-    WaypointMode waypoint_{WaypointMode::FULL_POSE};
+    WaypointMode waypoint_mode_{WaypointMode::FULL_POSE};
     double convergence_threshold_{0.1};
 };
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -3,6 +3,7 @@
 
 #include <mutex>
 #include <vortex/utils/types.hpp>
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
 #include "reference_filter_dp/lib/reference_filter.hpp"
 #include "reference_filter_dp/lib/waypoint_types.hpp"
 
@@ -10,15 +11,6 @@ namespace vortex::guidance {
 
 using vortex::utils::types::PoseEuler;
 using vortex::utils::types::Twist;
-
-/**
- * @brief Result of a single step of the waypoint follower.
- */
-struct StepResult {
-    Eigen::Vector18d
-        reference_state;  ///< Filter state: [pose, pose_dot, pose_ddot].
-    bool target_reached;  ///< True if measured pose has converged.
-};
 
 /**
  * @brief Manages reference filter state and waypoint following logic.
@@ -43,10 +35,16 @@ class WaypointFollower {
 
     /**
      * @brief Advance the filter by one time step.
-     * @param measured_pose Current measured pose for convergence checking.
-     * @return StepResult with the updated filter state and convergence status.
+     * @return  The updated filter state.
      */
-    StepResult step(const Eigen::Vector6d& measured_pose);
+    Eigen::Vector18d step();
+
+    /**
+     * @brief Check if the measured pose has converged to the reference goal.
+     * @param measured_pose Current measured pose.
+     * @return True if the error norm is within the convergence threshold.
+     */
+    bool within_convergance(const Eigen::Vector6d& measured_pose) const;
 
     /**
      * @brief Update the reference goal pose mid-sequence.

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_follower.hpp
@@ -1,10 +1,14 @@
 #ifndef REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_
 #define REFERENCE_FILTER_DP__LIB__WAYPOINT_FOLLOWER_HPP_
 
+#include <vortex/utils/types.hpp>
 #include "reference_filter_dp/lib/reference_filter.hpp"
 #include "reference_filter_dp/lib/waypoint_types.hpp"
 
 namespace vortex::guidance {
+
+using vortex::utils::types::PoseEuler;
+using vortex::utils::types::Twist;
 
 struct StepResult {
     Eigen::Vector18d state;
@@ -16,7 +20,8 @@ class WaypointFollower {
    public:
     WaypointFollower(const ReferenceFilterParams& params, double dt_seconds);
 
-    void start(const Eigen::Vector18d& initial_state,
+    void start(const PoseEuler& pose,
+               const Twist& twist,
                const Waypoint& waypoint,
                double convergence_threshold);
 
@@ -29,6 +34,9 @@ class WaypointFollower {
     void snap_state_to_reference();
 
    private:
+    Eigen::Vector18d compute_initial_state(const PoseEuler& pose,
+                                           const Twist& twist);
+
     ReferenceFilter filter_;
     double dt_seconds_;
     Eigen::Vector18d x_ = Eigen::Vector18d::Zero();

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_types.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_types.hpp
@@ -8,13 +8,22 @@ namespace vortex::guidance {
 
 using vortex::utils::types::PoseEuler;
 
+/**
+ * @brief Determines which degrees of freedom the reference filter controls.
+ *
+ * The mode affects both the reference goal computation (via apply_mode_logic)
+ * and the convergence check (via has_converged).
+ */
 enum class WaypointMode : uint8_t {
-    FULL_POSE = 0,
-    ONLY_POSITION = 1,
-    FORWARD_HEADING = 2,
-    ONLY_ORIENTATION = 3,
+    FULL_POSE = 0,         ///< Control all 6 DOF.
+    ONLY_POSITION = 1,     ///< Control x, y, z; hold current orientation.
+    FORWARD_HEADING = 2,   ///< Control x, y, z with yaw toward target.
+    ONLY_ORIENTATION = 3,  ///< Control roll, pitch, yaw; hold current position.
 };
 
+/**
+ * @brief A target pose with an associated waypoint mode.
+ */
 struct Waypoint {
     PoseEuler pose{};
     WaypointMode mode = WaypointMode::FULL_POSE;

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_types.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_types.hpp
@@ -2,9 +2,11 @@
 #define REFERENCE_FILTER_DP__LIB__WAYPOINT_TYPES_HPP_
 
 #include <cstdint>
-#include "reference_filter_dp/lib/eigen_typedefs.hpp"
+#include <vortex/utils/types.hpp>
 
 namespace vortex::guidance {
+
+using vortex::utils::types::PoseEuler;
 
 enum class WaypointMode : uint8_t {
     FULL_POSE = 0,
@@ -14,7 +16,7 @@ enum class WaypointMode : uint8_t {
 };
 
 struct Waypoint {
-    Eigen::Vector6d pose = Eigen::Vector6d::Zero();
+    PoseEuler pose{};
     WaypointMode mode = WaypointMode::FULL_POSE;
 };
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_types.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_types.hpp
@@ -1,0 +1,23 @@
+#ifndef REFERENCE_FILTER_DP__LIB__WAYPOINT_TYPES_HPP_
+#define REFERENCE_FILTER_DP__LIB__WAYPOINT_TYPES_HPP_
+
+#include <cstdint>
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
+
+namespace vortex::guidance {
+
+enum class WaypointMode : uint8_t {
+    FULL_POSE = 0,
+    ONLY_POSITION = 1,
+    FORWARD_HEADING = 2,
+    ONLY_ORIENTATION = 3,
+};
+
+struct Waypoint {
+    Eigen::Vector6d pose = Eigen::Vector6d::Zero();
+    WaypointMode mode = WaypointMode::FULL_POSE;
+};
+
+}  // namespace vortex::guidance
+
+#endif  // REFERENCE_FILTER_DP__LIB__WAYPOINT_TYPES_HPP_

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_utils.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_utils.hpp
@@ -1,0 +1,19 @@
+#ifndef REFERENCE_FILTER_DP__LIB__WAYPOINT_UTILS_HPP_
+#define REFERENCE_FILTER_DP__LIB__WAYPOINT_UTILS_HPP_
+
+#include "reference_filter_dp/lib/waypoint_types.hpp"
+
+namespace vortex::guidance {
+
+Eigen::Vector6d apply_mode_logic(const Eigen::Vector6d& r_in,
+                                 WaypointMode mode,
+                                 const Eigen::Vector6d& current_state);
+
+bool has_converged(const Eigen::Vector6d& measured_pose,
+                   const Eigen::Vector6d& reference,
+                   WaypointMode mode,
+                   double convergence_threshold);
+
+}  // namespace vortex::guidance
+
+#endif  // REFERENCE_FILTER_DP__LIB__WAYPOINT_UTILS_HPP_

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_utils.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_utils.hpp
@@ -6,10 +6,32 @@
 
 namespace vortex::guidance {
 
+/**
+ * @brief Apply waypoint mode logic to a reference pose.
+ *
+ * For modes that don't control all DOFs, the uncontrolled components are
+ * replaced with values from @p current_state so the filter holds them steady.
+ *
+ * @param r_in The raw reference pose (6D).
+ * @param mode The waypoint mode.
+ * @param current_state The current filter state pose (6D).
+ * @return The adjusted reference pose.
+ */
 Eigen::Vector6d apply_mode_logic(const Eigen::Vector6d& r_in,
                                  WaypointMode mode,
                                  const Eigen::Vector6d& current_state);
 
+/**
+ * @brief Check whether the measured pose has converged to the reference.
+ *
+ * Only the DOFs relevant to the waypoint mode are included in the error norm.
+ *
+ * @param measured_pose The current measured pose (6D).
+ * @param reference The reference goal pose (6D).
+ * @param mode The waypoint mode.
+ * @param convergence_threshold The maximum allowed error norm.
+ * @return True if the error is below the threshold.
+ */
 bool has_converged(const Eigen::Vector6d& measured_pose,
                    const Eigen::Vector6d& reference,
                    WaypointMode mode,

--- a/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_utils.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/lib/waypoint_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef REFERENCE_FILTER_DP__LIB__WAYPOINT_UTILS_HPP_
 #define REFERENCE_FILTER_DP__LIB__WAYPOINT_UTILS_HPP_
 
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
 #include "reference_filter_dp/lib/waypoint_types.hpp"
 
 namespace vortex::guidance {

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -1,5 +1,5 @@
-#ifndef REFERENCE_FILTER_DP__REFERENCE_FILTER_ROS_HPP_
-#define REFERENCE_FILTER_DP__REFERENCE_FILTER_ROS_HPP_
+#ifndef REFERENCE_FILTER_DP__ROS__REFERENCE_FILTER_ROS_HPP_
+#define REFERENCE_FILTER_DP__ROS__REFERENCE_FILTER_ROS_HPP_
 
 #include <atomic>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -11,8 +11,8 @@
 #include <vortex_msgs/action/reference_filter_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
-#include "reference_filter_dp/eigen_typedefs.hpp"
-#include "reference_filter_dp/reference_filter.hpp"
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
+#include "reference_filter_dp/lib/reference_filter.hpp"
 
 namespace vortex::guidance {
 
@@ -136,4 +136,4 @@ class ReferenceFilterNode : public rclcpp::Node {
 
 }  // namespace vortex::guidance
 
-#endif  // REFERENCE_FILTER_DP__REFERENCE_FILTER_ROS_HPP_
+#endif  // REFERENCE_FILTER_DP__ROS__REFERENCE_FILTER_ROS_HPP_

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -13,7 +13,6 @@
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
 #include "reference_filter_dp/lib/waypoint_follower.hpp"
-#include "reference_filter_dp/lib/waypoint_types.hpp"
 
 namespace vortex::guidance {
 
@@ -89,9 +88,6 @@ class ReferenceFilterNode : public rclcpp::Node {
     vortex::utils::types::PoseEuler current_pose_;
 
     vortex::utils::types::Twist current_twist_;
-
-    std::atomic<vortex::guidance::WaypointMode> active_mode_{
-        WaypointMode::FULL_POSE};
 
     std::mutex mutex_;
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -42,7 +42,7 @@ class ReferenceFilterNode : public rclcpp::Node {
         const std::shared_ptr<rclcpp_action::ServerGoalHandle<
             vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
 
-    /// @brief Spawn a detached thread to execute the goal.
+    /// @brief Join the old execution thread and spawn a new one for the goal.
     void handle_accepted(
         const std::shared_ptr<rclcpp_action::ServerGoalHandle<
             vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
@@ -51,12 +51,10 @@ class ReferenceFilterNode : public rclcpp::Node {
      * @brief Execute the action goal in a loop until convergence or
      * preemption.
      * @param goal_handle The goal handle.
-     * @param generation Generation counter used to detect preemption by a
-     * newer goal.
      */
-    void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                     vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
-                 uint64_t generation);
+    void execute(
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
 
     rclcpp_action::Server<
         vortex_msgs::action::ReferenceFilterWaypoint>::SharedPtr action_server_;
@@ -85,9 +83,11 @@ class ReferenceFilterNode : public rclcpp::Node {
 
     vortex::utils::types::Twist current_twist_;
 
-    std::mutex mutex_;
+    std::mutex sensor_mutex_;
 
-    std::atomic<uint64_t> goal_generation_{0};
+    std::atomic<bool> preempted_{false};
+    std::mutex execute_mutex_;
+    std::thread execute_thread_;
 };
 
 }  // namespace vortex::guidance

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
+#include <vortex/utils/types.hpp>
 #include <vortex_msgs/action/reference_filter_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
@@ -34,16 +35,6 @@ class ReferenceFilterNode : public rclcpp::Node {
     // @param msg The reference message
     void reference_callback(
         const geometry_msgs::msg::PoseStamped::SharedPtr msg);
-
-    // @brief Callback for the pose topic
-    // @param msg The pose message
-    void pose_callback(
-        const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
-
-    // @brief Callback for the twist topic
-    // @param msg The twist message
-    void twist_callback(
-        const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
 
     // @brief Handle the goal request
     // @param uuid The goal UUID
@@ -74,9 +65,8 @@ class ReferenceFilterNode : public rclcpp::Node {
                      vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
                  uint64_t generation);
 
-    Eigen::Vector18d fill_reference_state();
-
-    Eigen::Vector6d fill_reference_goal(const geometry_msgs::msg::Pose& goal);
+    vortex::utils::types::PoseEuler fill_reference_goal(
+        const geometry_msgs::msg::Pose& goal);
 
     Eigen::Vector6d measured_pose_vector6();
 
@@ -105,9 +95,9 @@ class ReferenceFilterNode : public rclcpp::Node {
 
     std::chrono::milliseconds time_step_{};
 
-    geometry_msgs::msg::PoseWithCovarianceStamped current_pose_;
+    vortex::utils::types::PoseEuler current_pose_;
 
-    geometry_msgs::msg::TwistWithCovarianceStamped current_twist_;
+    vortex::utils::types::Twist current_twist_;
 
     std::atomic<uint8_t> active_mode_{vortex_msgs::msg::Waypoint::FULL_POSE};
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -60,8 +60,6 @@ class ReferenceFilterNode : public rclcpp::Node {
                      vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
                  uint64_t generation);
 
-    Eigen::Vector6d measured_pose_vector6();
-
     rclcpp_action::Server<
         vortex_msgs::action::ReferenceFilterWaypoint>::SharedPtr action_server_;
 
@@ -92,8 +90,6 @@ class ReferenceFilterNode : public rclcpp::Node {
     std::mutex mutex_;
 
     std::atomic<uint64_t> goal_generation_{0};
-
-    rclcpp::CallbackGroup::SharedPtr cb_group_;
 };
 
 }  // namespace vortex::guidance

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -31,31 +31,29 @@ class ReferenceFilterNode : public rclcpp::Node {
     // @brief Initializes the reference filter with ROS parameters.
     void set_refererence_filter();
 
-    // @brief Handle the goal request
-    // @param uuid The goal UUID
-    // @param goal The goal message
-    // @return The goal response
+    /// @brief Accept all incoming goals unconditionally.
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
         std::shared_ptr<
             const vortex_msgs::action::ReferenceFilterWaypoint::Goal> goal);
 
-    // @brief Handle the cancel request
-    // @param goal_handle The goal handle
-    // @return The cancel response
+    /// @brief Accept all cancel requests.
     rclcpp_action::CancelResponse handle_cancel(
         const std::shared_ptr<rclcpp_action::ServerGoalHandle<
             vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
 
-    // @brief Handle the accepted request
-    // @param goal_handle The goal handle
+    /// @brief Spawn a detached thread to execute the goal.
     void handle_accepted(
         const std::shared_ptr<rclcpp_action::ServerGoalHandle<
             vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
 
-    // @brief Execute the goal
-    // @param goal_handle The goal handle
-    // @param generation The generation counter for this goal
+    /**
+     * @brief Execute the action goal in a loop until convergence or
+     * preemption.
+     * @param goal_handle The goal handle.
+     * @param generation Generation counter used to detect preemption by a
+     * newer goal.
+     */
     void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
                      vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
                  uint64_t generation);

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -21,6 +21,8 @@ class ReferenceFilterNode : public rclcpp::Node {
     explicit ReferenceFilterNode(
         const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
+    ~ReferenceFilterNode();
+
    private:
     // @brief Set the subscribers and publishers
     void set_subscribers_and_publisher();

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -13,6 +13,7 @@
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
 #include "reference_filter_dp/lib/waypoint_follower.hpp"
+#include "reference_filter_dp/lib/waypoint_types.hpp"
 
 namespace vortex::guidance {
 
@@ -30,11 +31,6 @@ class ReferenceFilterNode : public rclcpp::Node {
 
     // @brief Initializes the reference filter with ROS parameters.
     void set_refererence_filter();
-
-    // @brief Callback for the reference topic
-    // @param msg The reference message
-    void reference_callback(
-        const geometry_msgs::msg::PoseStamped::SharedPtr msg);
 
     // @brief Handle the goal request
     // @param uuid The goal UUID
@@ -65,12 +61,7 @@ class ReferenceFilterNode : public rclcpp::Node {
                      vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
                  uint64_t generation);
 
-    vortex::utils::types::PoseEuler fill_reference_goal(
-        const geometry_msgs::msg::Pose& goal);
-
     Eigen::Vector6d measured_pose_vector6();
-
-    vortex_msgs::msg::ReferenceFilter fill_reference_msg();
 
     rclcpp_action::Server<
         vortex_msgs::action::ReferenceFilterWaypoint>::SharedPtr action_server_;
@@ -99,7 +90,8 @@ class ReferenceFilterNode : public rclcpp::Node {
 
     vortex::utils::types::Twist current_twist_;
 
-    std::atomic<uint8_t> active_mode_{vortex_msgs::msg::Waypoint::FULL_POSE};
+    std::atomic<vortex::guidance::WaypointMode> active_mode_{
+        WaypointMode::FULL_POSE};
 
     std::mutex mutex_;
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -11,8 +11,7 @@
 #include <vortex_msgs/action/reference_filter_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
-#include "reference_filter_dp/lib/eigen_typedefs.hpp"
-#include "reference_filter_dp/lib/reference_filter.hpp"
+#include "reference_filter_dp/lib/waypoint_follower.hpp"
 
 namespace vortex::guidance {
 
@@ -81,21 +80,14 @@ class ReferenceFilterNode : public rclcpp::Node {
 
     Eigen::Vector6d measured_pose_vector6();
 
-    Eigen::Vector6d apply_mode_logic(const Eigen::Vector6d& r_in, uint8_t mode);
-
-    bool has_converged_against_pose(const Eigen::Vector6d& y,
-                                    const Eigen::Vector6d& r,
-                                    uint8_t mode,
-                                    double convergence_threshold) const;
-
-    void publish_hold_reference();
-
     vortex_msgs::msg::ReferenceFilter fill_reference_msg();
 
     rclcpp_action::Server<
         vortex_msgs::action::ReferenceFilterWaypoint>::SharedPtr action_server_;
 
-    std::unique_ptr<ReferenceFilter> reference_filter_{};
+    ReferenceFilterParams filter_params_;
+
+    std::unique_ptr<WaypointFollower> follower_;
 
     rclcpp::Publisher<vortex_msgs::msg::ReferenceFilter>::SharedPtr
         reference_pub_;
@@ -116,14 +108,6 @@ class ReferenceFilterNode : public rclcpp::Node {
     geometry_msgs::msg::PoseWithCovarianceStamped current_pose_;
 
     geometry_msgs::msg::TwistWithCovarianceStamped current_twist_;
-
-    // x is [eta, eta_dot, eta_dot_dot] (ref. page 337 in Fossen, 2021
-    // nu and eta are 6 degrees of freedom (position and orientation in 3D
-    // space)
-    Eigen::Vector18d x_ = Eigen::Vector18d::Zero();
-
-    // The reference signal vector with 6 degrees of freedom [eta]
-    Eigen::Vector6d r_ = Eigen::Vector6d::Zero();
 
     std::atomic<uint8_t> active_mode_{vortex_msgs::msg::Waypoint::FULL_POSE};
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros_utils.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros_utils.hpp
@@ -43,13 +43,14 @@ inline vortex::guidance::Waypoint waypoint_from_ros(
 /// @brief Fill a ReferenceFilter message from an 18D state vector.
 inline vortex_msgs::msg::ReferenceFilter fill_reference_msg(
     const Eigen::Vector18d& x) {
+    using vortex::utils::math::ssa;
     vortex_msgs::msg::ReferenceFilter msg;
     msg.x = x(0);
     msg.y = x(1);
     msg.z = x(2);
-    msg.roll = vortex::utils::math::ssa(x(3));
-    msg.pitch = vortex::utils::math::ssa(x(4));
-    msg.yaw = vortex::utils::math::ssa(x(5));
+    msg.roll = ssa(x(3));
+    msg.pitch = ssa(x(4));
+    msg.yaw = ssa(x(5));
     msg.x_dot = x(6);
     msg.y_dot = x(7);
     msg.z_dot = x(8);

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros_utils.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros_utils.hpp
@@ -12,6 +12,8 @@
 
 namespace vortex::guidance {
 
+/// @brief Convert a ROS waypoint mode to a WaypointMode enum.
+/// @throws std::invalid_argument if the mode value is not recognized.
 inline WaypointMode waypoint_mode_from_ros(uint8_t mode) {
     switch (mode) {
         case vortex_msgs::msg::Waypoint::FULL_POSE:
@@ -28,6 +30,7 @@ inline WaypointMode waypoint_mode_from_ros(uint8_t mode) {
     }
 }
 
+/// @brief Convert a ROS Waypoint message to an internal Waypoint struct.
 inline vortex::guidance::Waypoint waypoint_from_ros(
     const vortex_msgs::msg::Waypoint& ros_wp) {
     Waypoint wp;
@@ -37,6 +40,7 @@ inline vortex::guidance::Waypoint waypoint_from_ros(
     return wp;
 }
 
+/// @brief Fill a ReferenceFilter message from an 18D state vector.
 inline vortex_msgs::msg::ReferenceFilter fill_reference_msg(
     const Eigen::Vector18d& x) {
     vortex_msgs::msg::ReferenceFilter msg;

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros_utils.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros_utils.hpp
@@ -1,0 +1,60 @@
+#ifndef REFERENCE_FILTER_DP__ROS__REFERENCE_FILTER_ROS_UTILS_HPP_
+#define REFERENCE_FILTER_DP__ROS__REFERENCE_FILTER_ROS_UTILS_HPP_
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <vortex/utils/math.hpp>
+#include <vortex/utils/ros/ros_conversions.hpp>
+#include <vortex/utils/types.hpp>
+#include <vortex_msgs/msg/reference_filter.hpp>
+#include <vortex_msgs/msg/waypoint.hpp>
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
+#include "reference_filter_dp/lib/waypoint_types.hpp"
+
+namespace vortex::guidance {
+
+inline WaypointMode waypoint_mode_from_ros(uint8_t mode) {
+    switch (mode) {
+        case vortex_msgs::msg::Waypoint::FULL_POSE:
+            return WaypointMode::FULL_POSE;
+        case vortex_msgs::msg::Waypoint::ONLY_POSITION:
+            return WaypointMode::ONLY_POSITION;
+        case vortex_msgs::msg::Waypoint::FORWARD_HEADING:
+            return WaypointMode::FORWARD_HEADING;
+        case vortex_msgs::msg::Waypoint::ONLY_ORIENTATION:
+            return WaypointMode::ONLY_ORIENTATION;
+        default:
+            throw std::invalid_argument("Invalid ROS waypoint mode: " +
+                                        std::to_string(mode));
+    }
+}
+
+inline vortex::guidance::Waypoint waypoint_from_ros(
+    const vortex_msgs::msg::Waypoint& ros_wp) {
+    Waypoint wp;
+    wp.pose =
+        vortex::utils::ros_conversions::ros_pose_to_pose_euler(ros_wp.pose);
+    wp.mode = waypoint_mode_from_ros(ros_wp.mode);
+    return wp;
+}
+
+inline vortex_msgs::msg::ReferenceFilter fill_reference_msg(
+    const Eigen::Vector18d& x) {
+    vortex_msgs::msg::ReferenceFilter msg;
+    msg.x = x(0);
+    msg.y = x(1);
+    msg.z = x(2);
+    msg.roll = vortex::utils::math::ssa(x(3));
+    msg.pitch = vortex::utils::math::ssa(x(4));
+    msg.yaw = vortex::utils::math::ssa(x(5));
+    msg.x_dot = x(6);
+    msg.y_dot = x(7);
+    msg.z_dot = x(8);
+    msg.roll_dot = x(9);
+    msg.pitch_dot = x(10);
+    msg.yaw_dot = x(11);
+    return msg;
+}
+
+}  // namespace vortex::guidance
+
+#endif  // REFERENCE_FILTER_DP__ROS__REFERENCE_FILTER_ROS_UTILS_HPP_

--- a/guidance/reference_filter_dp/src/lib/reference_filter.cpp
+++ b/guidance/reference_filter_dp/src/lib/reference_filter.cpp
@@ -1,4 +1,4 @@
-#include "reference_filter_dp/reference_filter.hpp"
+#include "reference_filter_dp/lib/reference_filter.hpp"
 
 namespace vortex::guidance {
 

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -14,10 +14,10 @@ void WaypointFollower::start(const PoseEuler& pose,
                              double convergence_threshold) {
     std::lock_guard<std::mutex> lock(mutex_);
     x_ = compute_initial_state(pose, twist);
-    waypoint_ = waypoint.mode;
+    waypoint_mode_ = waypoint.mode;
     convergence_threshold_ = convergence_threshold;
-    reference_goal_ = apply_mode_logic(waypoint.pose.to_vector(), waypoint.mode,
-                                       x_.head<6>());
+    reference_goal_ = apply_mode_logic(waypoint.pose.to_vector(),
+                                       waypoint_mode_, x_.head<6>());
 }
 
 Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
@@ -41,17 +41,16 @@ StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
     Eigen::Vector18d x_dot = filter_.calculate_x_dot(x_, reference_goal_);
     x_ += x_dot * dt_seconds_;
 
-    bool converged = has_converged(measured_pose, reference_goal_, waypoint_,
-                                   convergence_threshold_);
+    bool converged = has_converged(measured_pose, reference_goal_,
+                                   waypoint_mode_, convergence_threshold_);
 
     return StepResult{x_, reference_goal_, converged};
 }
 
-void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose,
-                                     WaypointMode mode) {
+void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose) {
     std::lock_guard<std::mutex> lock(mutex_);
-    reference_goal_ =
-        apply_mode_logic(reference_goal_pose.to_vector(), mode, x_.head<6>());
+    reference_goal_ = apply_mode_logic(reference_goal_pose.to_vector(),
+                                       waypoint_mode_, x_.head<6>());
 }
 
 Eigen::Vector18d WaypointFollower::state() const {

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -1,0 +1,46 @@
+#include "reference_filter_dp/lib/waypoint_follower.hpp"
+#include "reference_filter_dp/lib/waypoint_utils.hpp"
+
+namespace vortex::guidance {
+
+WaypointFollower::WaypointFollower(const ReferenceFilterParams& params,
+                                   double dt_seconds)
+    : filter_(params), dt_seconds_(dt_seconds) {}
+
+void WaypointFollower::start(const Eigen::Vector18d& initial_state,
+                             const Waypoint& waypoint,
+                             double convergence_threshold) {
+    x_ = initial_state;
+    waypoint_ = waypoint;
+    convergence_threshold_ = convergence_threshold;
+    r_ = apply_mode_logic(waypoint.pose, waypoint.mode, x_.head<6>());
+}
+
+StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
+    Eigen::Vector18d x_dot = filter_.calculate_x_dot(x_, r_);
+    x_ += x_dot * dt_seconds_;
+
+    bool converged = has_converged(measured_pose, r_, waypoint_.mode,
+                                   convergence_threshold_);
+
+    return StepResult{x_, r_, converged};
+}
+
+void WaypointFollower::set_reference(const Eigen::Vector6d& r,
+                                     WaypointMode mode) {
+    r_ = apply_mode_logic(r, mode, x_.head<6>());
+}
+
+const Eigen::Vector18d& WaypointFollower::state() const {
+    return x_;
+}
+
+const Eigen::Vector6d& WaypointFollower::reference() const {
+    return r_;
+}
+
+void WaypointFollower::snap_state_to_reference() {
+    x_.head<6>() = r_;
+}
+
+}  // namespace vortex::guidance

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -15,8 +15,8 @@ void WaypointFollower::start(const PoseEuler& pose,
     x_ = compute_initial_state(pose, twist);
     waypoint_ = waypoint;
     convergence_threshold_ = convergence_threshold;
-    r_ = apply_mode_logic(waypoint.pose.to_vector(), waypoint.mode,
-                          x_.head<6>());
+    reference_goal_ = apply_mode_logic(waypoint.pose.to_vector(), waypoint.mode,
+                                       x_.head<6>());
 }
 
 Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
@@ -36,18 +36,19 @@ Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
 }
 
 StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
-    Eigen::Vector18d x_dot = filter_.calculate_x_dot(x_, r_);
+    Eigen::Vector18d x_dot = filter_.calculate_x_dot(x_, reference_goal_);
     x_ += x_dot * dt_seconds_;
 
-    bool converged = has_converged(measured_pose, r_, waypoint_.mode,
-                                   convergence_threshold_);
+    bool converged = has_converged(measured_pose, reference_goal_,
+                                   waypoint_.mode, convergence_threshold_);
 
-    return StepResult{x_, r_, converged};
+    return StepResult{x_, reference_goal_, converged};
 }
 
-void WaypointFollower::set_reference(const Eigen::Vector6d& r,
+void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose,
                                      WaypointMode mode) {
-    r_ = apply_mode_logic(r, mode, x_.head<6>());
+    reference_goal_ =
+        apply_mode_logic(reference_goal_pose.to_vector(), mode, x_.head<6>());
 }
 
 const Eigen::Vector18d& WaypointFollower::state() const {
@@ -55,11 +56,11 @@ const Eigen::Vector18d& WaypointFollower::state() const {
 }
 
 const Eigen::Vector6d& WaypointFollower::reference() const {
-    return r_;
+    return reference_goal_;
 }
 
 void WaypointFollower::snap_state_to_reference() {
-    x_.head<6>() = r_;
+    x_.head<6>() = reference_goal_;
 }
 
 }  // namespace vortex::guidance

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -13,11 +13,11 @@ void WaypointFollower::start(const PoseEuler& pose,
                              const Waypoint& waypoint,
                              double convergence_threshold) {
     std::lock_guard<std::mutex> lock(mutex_);
-    x_ = compute_initial_state(pose, twist);
+    state_ = compute_initial_state(pose, twist);
     waypoint_mode_ = waypoint.mode;
     convergence_threshold_ = convergence_threshold;
     reference_goal_ = apply_mode_logic(waypoint.pose.to_vector(),
-                                       waypoint_mode_, x_.head<6>());
+                                       waypoint_mode_, state_.head<6>());
 }
 
 Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
@@ -34,24 +34,25 @@ Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
 
 StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
     std::lock_guard<std::mutex> lock(mutex_);
-    Eigen::Vector18d x_dot = filter_.calculate_x_dot(x_, reference_goal_);
-    x_ += x_dot * dt_seconds_;
+    Eigen::Vector18d state_dot_ =
+        filter_.calculate_x_dot(state_, reference_goal_);
+    state_ += state_dot_ * dt_seconds_;
 
     bool converged = has_converged(measured_pose, reference_goal_,
                                    waypoint_mode_, convergence_threshold_);
 
-    return StepResult{x_, converged};
+    return StepResult{state_, converged};
 }
 
 void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose) {
     std::lock_guard<std::mutex> lock(mutex_);
     reference_goal_ = apply_mode_logic(reference_goal_pose.to_vector(),
-                                       waypoint_mode_, x_.head<6>());
+                                       waypoint_mode_, state_.head<6>());
 }
 
 Eigen::Vector18d WaypointFollower::state() const {
     std::lock_guard<std::mutex> lock(mutex_);
-    return x_;
+    return state_;
 }
 
 Eigen::Vector6d WaypointFollower::reference() const {
@@ -61,7 +62,7 @@ Eigen::Vector6d WaypointFollower::reference() const {
 
 void WaypointFollower::snap_state_to_reference() {
     std::lock_guard<std::mutex> lock(mutex_);
-    x_.head<6>() = reference_goal_;
+    state_.head<6>() = reference_goal_;
 }
 
 }  // namespace vortex::guidance

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -12,8 +12,9 @@ void WaypointFollower::start(const PoseEuler& pose,
                              const Twist& twist,
                              const Waypoint& waypoint,
                              double convergence_threshold) {
+    std::lock_guard<std::mutex> lock(mutex_);
     x_ = compute_initial_state(pose, twist);
-    waypoint_ = waypoint;
+    waypoint_ = waypoint.mode;
     convergence_threshold_ = convergence_threshold;
     reference_goal_ = apply_mode_logic(waypoint.pose.to_vector(), waypoint.mode,
                                        x_.head<6>());
@@ -36,30 +37,35 @@ Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
 }
 
 StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
+    std::lock_guard<std::mutex> lock(mutex_);
     Eigen::Vector18d x_dot = filter_.calculate_x_dot(x_, reference_goal_);
     x_ += x_dot * dt_seconds_;
 
-    bool converged = has_converged(measured_pose, reference_goal_,
-                                   waypoint_.mode, convergence_threshold_);
+    bool converged = has_converged(measured_pose, reference_goal_, waypoint_,
+                                   convergence_threshold_);
 
     return StepResult{x_, reference_goal_, converged};
 }
 
 void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose,
                                      WaypointMode mode) {
+    std::lock_guard<std::mutex> lock(mutex_);
     reference_goal_ =
         apply_mode_logic(reference_goal_pose.to_vector(), mode, x_.head<6>());
 }
 
-const Eigen::Vector18d& WaypointFollower::state() const {
+Eigen::Vector18d WaypointFollower::state() const {
+    std::lock_guard<std::mutex> lock(mutex_);
     return x_;
 }
 
-const Eigen::Vector6d& WaypointFollower::reference() const {
+Eigen::Vector6d WaypointFollower::reference() const {
+    std::lock_guard<std::mutex> lock(mutex_);
     return reference_goal_;
 }
 
 void WaypointFollower::snap_state_to_reference() {
+    std::lock_guard<std::mutex> lock(mutex_);
     x_.head<6>() = reference_goal_;
 }
 

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -1,5 +1,6 @@
 #include "reference_filter_dp/lib/waypoint_follower.hpp"
 #include <vortex/utils/math.hpp>
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
 #include "reference_filter_dp/lib/waypoint_utils.hpp"
 
 namespace vortex::guidance {
@@ -32,16 +33,20 @@ Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
     return x;
 }
 
-StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
+Eigen::Vector18d WaypointFollower::step() {
     std::lock_guard<std::mutex> lock(mutex_);
     Eigen::Vector18d state_dot_ =
         filter_.calculate_x_dot(state_, reference_goal_);
     state_ += state_dot_ * dt_seconds_;
 
-    bool converged = has_converged(measured_pose, reference_goal_,
-                                   waypoint_mode_, convergence_threshold_);
+    return state_;
+}
 
-    return StepResult{state_, converged};
+bool WaypointFollower::within_convergance(
+    const Eigen::Vector6d& measured_pose) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return has_converged(measured_pose, reference_goal_, waypoint_mode_,
+                         convergence_threshold_);
 }
 
 void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose) {

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -1,4 +1,5 @@
 #include "reference_filter_dp/lib/waypoint_follower.hpp"
+#include <vortex/utils/math.hpp>
 #include "reference_filter_dp/lib/waypoint_utils.hpp"
 
 namespace vortex::guidance {
@@ -7,13 +8,31 @@ WaypointFollower::WaypointFollower(const ReferenceFilterParams& params,
                                    double dt_seconds)
     : filter_(params), dt_seconds_(dt_seconds) {}
 
-void WaypointFollower::start(const Eigen::Vector18d& initial_state,
+void WaypointFollower::start(const PoseEuler& pose,
+                             const Twist& twist,
                              const Waypoint& waypoint,
                              double convergence_threshold) {
-    x_ = initial_state;
+    x_ = compute_initial_state(pose, twist);
     waypoint_ = waypoint;
     convergence_threshold_ = convergence_threshold;
-    r_ = apply_mode_logic(waypoint.pose, waypoint.mode, x_.head<6>());
+    r_ = apply_mode_logic(waypoint.pose.to_vector(), waypoint.mode,
+                          x_.head<6>());
+}
+
+Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
+                                                         const Twist& twist) {
+    Eigen::Vector18d x = Eigen::Vector18d::Zero();
+
+    Eigen::Vector6d pose_vec = pose.to_vector();
+    pose_vec(3) = vortex::utils::math::ssa(pose_vec(3));
+    pose_vec(4) = vortex::utils::math::ssa(pose_vec(4));
+    pose_vec(5) = vortex::utils::math::ssa(pose_vec(5));
+    x.head<6>() = pose_vec;
+
+    Eigen::Matrix<double, 6, 6> J = pose.as_j_matrix();
+    x.segment<6>(6) = J * twist.to_vector();
+
+    return x;
 }
 
 StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {

--- a/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_follower.cpp
@@ -24,11 +24,7 @@ Eigen::Vector18d WaypointFollower::compute_initial_state(const PoseEuler& pose,
                                                          const Twist& twist) {
     Eigen::Vector18d x = Eigen::Vector18d::Zero();
 
-    Eigen::Vector6d pose_vec = pose.to_vector();
-    pose_vec(3) = vortex::utils::math::ssa(pose_vec(3));
-    pose_vec(4) = vortex::utils::math::ssa(pose_vec(4));
-    pose_vec(5) = vortex::utils::math::ssa(pose_vec(5));
-    x.head<6>() = pose_vec;
+    x.head<6>() = pose.to_vector();
 
     Eigen::Matrix<double, 6, 6> J = pose.as_j_matrix();
     x.segment<6>(6) = J * twist.to_vector();
@@ -44,7 +40,7 @@ StepResult WaypointFollower::step(const Eigen::Vector6d& measured_pose) {
     bool converged = has_converged(measured_pose, reference_goal_,
                                    waypoint_mode_, convergence_threshold_);
 
-    return StepResult{x_, reference_goal_, converged};
+    return StepResult{x_, converged};
 }
 
 void WaypointFollower::set_reference(const PoseEuler& reference_goal_pose) {

--- a/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
@@ -44,12 +44,13 @@ bool has_converged(const Eigen::Vector6d& measured_pose,
                    const Eigen::Vector6d& reference,
                    WaypointMode mode,
                    double convergence_threshold) {
+    using vortex::utils::math::ssa;
     const Eigen::Vector3d ep = measured_pose.head<3>() - reference.head<3>();
 
     Eigen::Vector3d ea;
-    ea(0) = vortex::utils::math::ssa(measured_pose(3) - reference(3));
-    ea(1) = vortex::utils::math::ssa(measured_pose(4) - reference(4));
-    ea(2) = vortex::utils::math::ssa(measured_pose(5) - reference(5));
+    ea(0) = ssa(measured_pose(3) - reference(3));
+    ea(1) = ssa(measured_pose(4) - reference(4));
+    ea(2) = ssa(measured_pose(5) - reference(5));
 
     double err = 0.0;
 

--- a/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
@@ -4,40 +4,40 @@
 
 namespace vortex::guidance {
 
-Eigen::Vector6d apply_mode_logic(const Eigen::Vector6d& r_in,
+Eigen::Vector6d apply_mode_logic(const Eigen::Vector6d& reference_in,
                                  WaypointMode mode,
                                  const Eigen::Vector6d& current_state) {
-    Eigen::Vector6d r_out = r_in;
+    Eigen::Vector6d reference_out = reference_in;
 
     switch (mode) {
         case WaypointMode::FULL_POSE:
             break;
 
         case WaypointMode::ONLY_POSITION:
-            r_out(3) = current_state(3);
-            r_out(4) = current_state(4);
-            r_out(5) = current_state(5);
+            reference_out(3) = current_state(3);
+            reference_out(4) = current_state(4);
+            reference_out(5) = current_state(5);
             break;
 
         case WaypointMode::FORWARD_HEADING: {
-            double dx = r_in(0) - current_state(0);
-            double dy = r_in(1) - current_state(1);
+            double dx = reference_in(0) - current_state(0);
+            double dy = reference_in(1) - current_state(1);
             double forward_heading = std::atan2(dy, dx);
 
-            r_out(3) = 0.0;
-            r_out(4) = 0.0;
-            r_out(5) = vortex::utils::math::ssa(forward_heading);
+            reference_out(3) = 0.0;
+            reference_out(4) = 0.0;
+            reference_out(5) = vortex::utils::math::ssa(forward_heading);
             break;
         }
 
         case WaypointMode::ONLY_ORIENTATION:
-            r_out(0) = current_state(0);
-            r_out(1) = current_state(1);
-            r_out(2) = current_state(2);
+            reference_out(0) = current_state(0);
+            reference_out(1) = current_state(1);
+            reference_out(2) = current_state(2);
             break;
     }
 
-    return r_out;
+    return reference_out;
 }
 
 bool has_converged(const Eigen::Vector6d& measured_pose,

--- a/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
@@ -1,0 +1,78 @@
+#include "reference_filter_dp/lib/waypoint_utils.hpp"
+#include <cmath>
+#include <vortex/utils/math.hpp>
+
+namespace vortex::guidance {
+
+Eigen::Vector6d apply_mode_logic(const Eigen::Vector6d& r_in,
+                                 WaypointMode mode,
+                                 const Eigen::Vector6d& current_state) {
+    Eigen::Vector6d r_out = r_in;
+
+    switch (mode) {
+        case WaypointMode::FULL_POSE:
+            break;
+
+        case WaypointMode::ONLY_POSITION:
+            r_out(3) = current_state(3);
+            r_out(4) = current_state(4);
+            r_out(5) = current_state(5);
+            break;
+
+        case WaypointMode::FORWARD_HEADING: {
+            double dx = r_in(0) - current_state(0);
+            double dy = r_in(1) - current_state(1);
+            double forward_heading = std::atan2(dy, dx);
+
+            r_out(3) = 0.0;
+            r_out(4) = 0.0;
+            r_out(5) = vortex::utils::math::ssa(forward_heading);
+            break;
+        }
+
+        case WaypointMode::ONLY_ORIENTATION:
+            r_out(0) = current_state(0);
+            r_out(1) = current_state(1);
+            r_out(2) = current_state(2);
+            break;
+    }
+
+    return r_out;
+}
+
+bool has_converged(const Eigen::Vector6d& measured_pose,
+                   const Eigen::Vector6d& reference,
+                   WaypointMode mode,
+                   double convergence_threshold) {
+    const Eigen::Vector3d ep = measured_pose.head<3>() - reference.head<3>();
+
+    Eigen::Vector3d ea;
+    ea(0) = vortex::utils::math::ssa(measured_pose(3) - reference(3));
+    ea(1) = vortex::utils::math::ssa(measured_pose(4) - reference(4));
+    ea(2) = vortex::utils::math::ssa(measured_pose(5) - reference(5));
+
+    double err = 0.0;
+
+    switch (mode) {
+        case WaypointMode::ONLY_POSITION:
+            err = ep.norm();
+            break;
+
+        case WaypointMode::ONLY_ORIENTATION:
+            err = ea.norm();
+            break;
+
+        case WaypointMode::FORWARD_HEADING:
+            err = std::sqrt(ep.squaredNorm() + ea(2) * ea(2));
+            break;
+
+        case WaypointMode::FULL_POSE:
+        default:
+            err = std::sqrt(ep.squaredNorm() + ea.squaredNorm());
+            break;
+    }
+
+    return err < convergence_threshold;
+}
+
+}  // namespace vortex::guidance

--- a/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
+++ b/guidance/reference_filter_dp/src/lib/waypoint_utils.cpp
@@ -52,26 +52,19 @@ bool has_converged(const Eigen::Vector6d& measured_pose,
     ea(1) = ssa(measured_pose(4) - reference(4));
     ea(2) = ssa(measured_pose(5) - reference(5));
 
-    double err = 0.0;
-
-    switch (mode) {
-        case WaypointMode::ONLY_POSITION:
-            err = ep.norm();
-            break;
-
-        case WaypointMode::ONLY_ORIENTATION:
-            err = ea.norm();
-            break;
-
-        case WaypointMode::FORWARD_HEADING:
-            err = std::sqrt(ep.squaredNorm() + ea(2) * ea(2));
-            break;
-
-        case WaypointMode::FULL_POSE:
-        default:
-            err = std::sqrt(ep.squaredNorm() + ea.squaredNorm());
-            break;
-    }
+    const double err = [&] {
+        switch (mode) {
+            case WaypointMode::ONLY_POSITION:
+                return ep.norm();
+            case WaypointMode::ONLY_ORIENTATION:
+                return ea.norm();
+            case WaypointMode::FORWARD_HEADING:
+                return std::sqrt(ep.squaredNorm() + ea(2) * ea(2));
+            case WaypointMode::FULL_POSE:
+            default:
+                return std::sqrt(ep.squaredNorm() + ea.squaredNorm());
+        }
+    }();
 
     return err < convergence_threshold;
 }

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -52,11 +52,9 @@ void ReferenceFilterNode::set_subscribers_and_publisher() {
     reference_sub_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
         reference_pose_topic, qos_sensor_data,
         [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
-            const auto reference_goal_pose =
+            follower_->set_reference(
                 vortex::utils::ros_conversions::ros_pose_to_pose_euler(
-                    msg->pose);
-            const auto mode = active_mode_.load();
-            follower_->set_reference(reference_goal_pose, mode);
+                    msg->pose));
         });
 
     pose_sub_ = this->create_subscription<

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -108,21 +108,10 @@ void ReferenceFilterNode::set_refererence_filter() {
 
 void ReferenceFilterNode::reference_callback(
     const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
-    double x = msg->pose.position.x;
-    double y = msg->pose.position.y;
-    double z = msg->pose.position.z;
-    const auto& o = msg->pose.orientation;
-    Eigen::Quaterniond q(o.w, o.x, o.y, o.z);
-    Eigen::Vector3d euler_angles = vortex::utils::math::quat_to_euler(q);
-    double roll{euler_angles(0)};
-    double pitch{euler_angles(1)};
-    double yaw{euler_angles(2)};
-
-    Eigen::Vector6d r_temp;
-    r_temp << x, y, z, roll, pitch, yaw;
-
-    auto mode = static_cast<WaypointMode>(active_mode_.load());
-    follower_->set_reference(r_temp, mode);
+    const auto reference_goal_pose =
+        vortex::utils::ros_conversions::ros_pose_to_pose_euler(msg->pose);
+    const auto mode = static_cast<WaypointMode>(active_mode_.load());
+    follower_->set_reference(reference_goal_pose, mode);
 }
 
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -1,11 +1,11 @@
 #include "reference_filter_dp/ros/reference_filter_ros.hpp"
 #include <spdlog/spdlog.h>
+#include <mutex>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <thread>
-#include <vortex/utils/math.hpp>
 #include <vortex/utils/ros/qos_profiles.hpp>
 #include <vortex/utils/ros/ros_conversions.hpp>
-#include <vortex/utils/types.hpp>
+#include "reference_filter_dp/ros/reference_filter_ros_utils.hpp"
 
 const auto start_message = R"(
   ____       __                                _____ _ _ _
@@ -48,10 +48,17 @@ void ReferenceFilterNode::set_subscribers_and_publisher() {
     auto qos_sensor_data = vortex::utils::qos_profiles::sensor_data_profile(1);
     reference_pub_ = this->create_publisher<vortex_msgs::msg::ReferenceFilter>(
         guidance_topic, qos_sensor_data);
+
     reference_sub_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
         reference_pose_topic, qos_sensor_data,
-        std::bind(&ReferenceFilterNode::reference_callback, this,
-                  std::placeholders::_1));
+        [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+            const auto reference_goal_pose =
+                vortex::utils::ros_conversions::ros_pose_to_pose_euler(
+                    msg->pose);
+            const auto mode = active_mode_.load();
+            follower_->set_reference(reference_goal_pose, mode);
+        });
+
     pose_sub_ = this->create_subscription<
         geometry_msgs::msg::PoseWithCovarianceStamped>(
         pose_topic, qos_sensor_data,
@@ -62,6 +69,7 @@ void ReferenceFilterNode::set_subscribers_and_publisher() {
                 vortex::utils::ros_conversions::ros_pose_to_pose_euler(
                     msg->pose.pose);
         });
+
     twist_sub_ = this->create_subscription<
         geometry_msgs::msg::TwistWithCovarianceStamped>(
         twist_topic, qos_sensor_data,
@@ -106,14 +114,6 @@ void ReferenceFilterNode::set_refererence_filter() {
     follower_ = std::make_unique<WaypointFollower>(filter_params_, dt_seconds);
 }
 
-void ReferenceFilterNode::reference_callback(
-    const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
-    const auto reference_goal_pose =
-        vortex::utils::ros_conversions::ros_pose_to_pose_euler(msg->pose);
-    const auto mode = static_cast<WaypointMode>(active_mode_.load());
-    follower_->set_reference(reference_goal_pose, mode);
-}
-
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
     const rclcpp_action::GoalUUID& uuid,
     std::shared_ptr<const vortex_msgs::action::ReferenceFilterWaypoint::Goal>
@@ -148,39 +148,12 @@ Eigen::Vector6d ReferenceFilterNode::measured_pose_vector6() {
     return pose.to_vector();
 }
 
-vortex::utils::types::PoseEuler ReferenceFilterNode::fill_reference_goal(
-    const geometry_msgs::msg::Pose& goal) {
-    return vortex::utils::ros_conversions::ros_pose_to_pose_euler(goal);
-}
-
-vortex_msgs::msg::ReferenceFilter ReferenceFilterNode::fill_reference_msg() {
-    vortex_msgs::msg::ReferenceFilter feedback_msg;
-    const Eigen::Vector18d& x = follower_->state();
-    feedback_msg.x = x(0);
-    feedback_msg.y = x(1);
-    feedback_msg.z = x(2);
-    feedback_msg.roll = vortex::utils::math::ssa(x(3));
-    feedback_msg.pitch = vortex::utils::math::ssa(x(4));
-    feedback_msg.yaw = vortex::utils::math::ssa(x(5));
-    feedback_msg.x_dot = x(6);
-    feedback_msg.y_dot = x(7);
-    feedback_msg.z_dot = x(8);
-    feedback_msg.roll_dot = x(9);
-    feedback_msg.pitch_dot = x(10);
-    feedback_msg.yaw_dot = x(11);
-
-    return feedback_msg;
-}
-
 void ReferenceFilterNode::execute(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
         vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
     uint64_t generation) {
     spdlog::info("Executing goal");
 
-    const geometry_msgs::msg::Pose goal =
-        goal_handle->get_goal()->waypoint.pose;
-    uint8_t mode = goal_handle->get_goal()->waypoint.mode;
     double convergence_threshold =
         goal_handle->get_goal()->convergence_threshold;
 
@@ -191,11 +164,7 @@ void ReferenceFilterNode::execute(
             "Using default 0.1");
     }
 
-    active_mode_ = mode;
-
-    Waypoint wp;
-    wp.pose = fill_reference_goal(goal);
-    wp.mode = static_cast<WaypointMode>(mode);
+    Waypoint wp = waypoint_from_ros(goal_handle->get_goal()->waypoint);
 
     PoseEuler pose;
     Twist twist;
@@ -236,19 +205,20 @@ void ReferenceFilterNode::execute(
         Eigen::Vector6d y = measured_pose_vector6();
         StepResult step = follower_->step(y);
 
-        vortex_msgs::msg::ReferenceFilter feedback_msg = fill_reference_msg();
+        vortex_msgs::msg::ReferenceFilter reference_msg =
+            fill_reference_msg(follower_->state());
 
-        feedback->reference = feedback_msg;
+        feedback->reference = reference_msg;
 
         goal_handle->publish_feedback(feedback);
-        reference_pub_->publish(feedback_msg);
+        reference_pub_->publish(reference_msg);
 
         if (step.converged) {
             result->success = true;
             goal_handle->succeed(result);
             follower_->snap_state_to_reference();
             vortex_msgs::msg::ReferenceFilter feedback_msg =
-                fill_reference_msg();
+                fill_reference_msg(follower_->state());
             reference_pub_->publish(feedback_msg);
             spdlog::info("Goal reached");
             return;

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -139,13 +139,6 @@ void ReferenceFilterNode::handle_accepted(
     }).detach();
 }
 
-Eigen::Vector6d ReferenceFilterNode::measured_pose_vector6() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    vortex::utils::types::PoseEuler pose = current_pose_;
-    pose.apply_ssa();
-    return pose.to_vector();
-}
-
 void ReferenceFilterNode::execute(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
         vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
@@ -200,8 +193,13 @@ void ReferenceFilterNode::execute(
             return;
         }
 
-        Eigen::Vector6d y = measured_pose_vector6();
-        StepResult step = follower_->step(y);
+        Eigen::Vector6d current_pose_vector;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            current_pose_vector = current_pose_.to_vector();
+        }
+
+        StepResult step = follower_->step(current_pose_vector);
 
         vortex_msgs::msg::ReferenceFilter reference_msg =
             fill_reference_msg(follower_->state());

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -32,6 +32,13 @@ ReferenceFilterNode::ReferenceFilterNode(const rclcpp::NodeOptions& options)
     spdlog::info(start_message);
 }
 
+ReferenceFilterNode::~ReferenceFilterNode() {
+    preempted_ = true;
+    if (execute_thread_.joinable()) {
+        execute_thread_.join();
+    }
+}
+
 void ReferenceFilterNode::set_subscribers_and_publisher() {
     this->declare_parameter<std::string>("topics.pose");
     this->declare_parameter<std::string>("topics.twist");

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -90,8 +90,10 @@ void ReferenceFilterNode::set_refererence_filter() {
     Eigen::Vector6d zeta_eigen = Eigen::Map<Eigen::Vector6d>(zeta.data());
     Eigen::Vector6d omega_eigen = Eigen::Map<Eigen::Vector6d>(omega.data());
 
-    ReferenceFilterParams filter_params{omega_eigen, zeta_eigen};
-    reference_filter_ = std::make_unique<ReferenceFilter>(filter_params);
+    filter_params_ = ReferenceFilterParams{omega_eigen, zeta_eigen};
+
+    double dt_seconds = time_step_.count() / 1000.0;
+    follower_ = std::make_unique<WaypointFollower>(filter_params_, dt_seconds);
 }
 
 void ReferenceFilterNode::reference_callback(
@@ -109,7 +111,8 @@ void ReferenceFilterNode::reference_callback(
     Eigen::Vector6d r_temp;
     r_temp << x, y, z, roll, pitch, yaw;
 
-    r_ = apply_mode_logic(r_temp, active_mode_.load());
+    auto mode = static_cast<WaypointMode>(active_mode_.load());
+    follower_->set_reference(r_temp, mode);
 }
 
 void ReferenceFilterNode::pose_callback(
@@ -245,93 +248,21 @@ Eigen::Vector6d ReferenceFilterNode::fill_reference_goal(
 
 vortex_msgs::msg::ReferenceFilter ReferenceFilterNode::fill_reference_msg() {
     vortex_msgs::msg::ReferenceFilter feedback_msg;
-    feedback_msg.x = x_(0);
-    feedback_msg.y = x_(1);
-    feedback_msg.z = x_(2);
-    feedback_msg.roll = vortex::utils::math::ssa(x_(3));
-    feedback_msg.pitch = vortex::utils::math::ssa(x_(4));
-    feedback_msg.yaw = vortex::utils::math::ssa(x_(5));
-    feedback_msg.x_dot = x_(6);
-    feedback_msg.y_dot = x_(7);
-    feedback_msg.z_dot = x_(8);
-    feedback_msg.roll_dot = x_(9);
-    feedback_msg.pitch_dot = x_(10);
-    feedback_msg.yaw_dot = x_(11);
+    const Eigen::Vector18d& x = follower_->state();
+    feedback_msg.x = x(0);
+    feedback_msg.y = x(1);
+    feedback_msg.z = x(2);
+    feedback_msg.roll = vortex::utils::math::ssa(x(3));
+    feedback_msg.pitch = vortex::utils::math::ssa(x(4));
+    feedback_msg.yaw = vortex::utils::math::ssa(x(5));
+    feedback_msg.x_dot = x(6);
+    feedback_msg.y_dot = x(7);
+    feedback_msg.z_dot = x(8);
+    feedback_msg.roll_dot = x(9);
+    feedback_msg.pitch_dot = x(10);
+    feedback_msg.yaw_dot = x(11);
 
     return feedback_msg;
-}
-
-Eigen::Vector6d ReferenceFilterNode::apply_mode_logic(
-    const Eigen::Vector6d& r_in,
-    uint8_t mode) {
-    Eigen::Vector6d r_out = r_in;
-
-    switch (mode) {
-        case vortex_msgs::msg::Waypoint::FULL_POSE:
-            break;
-
-        case vortex_msgs::msg::Waypoint::ONLY_POSITION:
-            r_out(3) = x_(3);
-            r_out(4) = x_(4);
-            r_out(5) = x_(5);
-            break;
-
-        case vortex_msgs::msg::Waypoint::FORWARD_HEADING: {
-            double dx = r_in(0) - x_(0);
-            double dy = r_in(1) - x_(1);
-
-            double forward_heading = std::atan2(dy, dx);
-
-            r_out(3) = 0.0;
-            r_out(4) = 0.0;
-            r_out(5) = vortex::utils::math::ssa(forward_heading);
-            break;
-        }
-
-        case vortex_msgs::msg::Waypoint::ONLY_ORIENTATION:
-            r_out(0) = x_(0);
-            r_out(1) = x_(1);
-            r_out(2) = x_(2);
-            break;
-    }
-
-    return r_out;
-}
-
-bool ReferenceFilterNode::has_converged_against_pose(
-    const Eigen::Vector6d& y,
-    const Eigen::Vector6d& r,
-    uint8_t mode,
-    double convergence_threshold) const {
-    const Eigen::Vector3d ep = y.head<3>() - r.head<3>();
-
-    Eigen::Vector3d ea;
-    ea(0) = vortex::utils::math::ssa(y(3) - r(3));
-    ea(1) = vortex::utils::math::ssa(y(4) - r(4));
-    ea(2) = vortex::utils::math::ssa(y(5) - r(5));
-
-    double err = 0.0;
-
-    switch (mode) {
-        case vortex_msgs::msg::Waypoint::ONLY_POSITION:
-            err = ep.norm();
-            break;
-
-        case vortex_msgs::msg::Waypoint::ONLY_ORIENTATION:
-            err = ea.norm();
-            break;
-
-        case vortex_msgs::msg::Waypoint::FORWARD_HEADING:
-            err = std::sqrt(ep.squaredNorm() + ea(2) * ea(2));
-            break;
-
-        case vortex_msgs::msg::Waypoint::FULL_POSE:
-        default:
-            err = std::sqrt(ep.squaredNorm() + ea.squaredNorm());
-            break;
-    }
-
-    return err < convergence_threshold;
 }
 
 void ReferenceFilterNode::execute(
@@ -340,7 +271,7 @@ void ReferenceFilterNode::execute(
     uint64_t generation) {
     spdlog::info("Executing goal");
 
-    x_ = fill_reference_state();
+    Eigen::Vector18d initial_state = fill_reference_state();
 
     const geometry_msgs::msg::Pose goal =
         goal_handle->get_goal()->waypoint.pose;
@@ -357,7 +288,11 @@ void ReferenceFilterNode::execute(
 
     Eigen::Vector6d r_temp = fill_reference_goal(goal);
     active_mode_ = mode;
-    r_ = apply_mode_logic(r_temp, active_mode_.load());
+
+    Waypoint wp;
+    wp.pose = r_temp;
+    wp.mode = static_cast<WaypointMode>(mode);
+    follower_->start(initial_state, wp, convergence_threshold);
 
     auto feedback = std::make_shared<
         vortex_msgs::action::ReferenceFilterWaypoint::Feedback>();
@@ -386,8 +321,8 @@ void ReferenceFilterNode::execute(
             return;
         }
 
-        Eigen::Vector18d x_dot = reference_filter_->calculate_x_dot(x_, r_);
-        x_ += x_dot * time_step_.count() / 1000.0;
+        Eigen::Vector6d y = measured_pose_vector6();
+        StepResult step = follower_->step(y);
 
         vortex_msgs::msg::ReferenceFilter feedback_msg = fill_reference_msg();
 
@@ -396,12 +331,10 @@ void ReferenceFilterNode::execute(
         goal_handle->publish_feedback(feedback);
         reference_pub_->publish(feedback_msg);
 
-        Eigen::Vector6d y = measured_pose_vector6();
-
-        if (has_converged_against_pose(y, r_, mode, convergence_threshold)) {
+        if (step.converged) {
             result->success = true;
             goal_handle->succeed(result);
-            x_.head(6) = r_.head(6);
+            follower_->snap_state_to_reference();
             vortex_msgs::msg::ReferenceFilter feedback_msg =
                 fill_reference_msg();
             reference_pub_->publish(feedback_msg);

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -118,20 +118,17 @@ void ReferenceFilterNode::set_refererence_filter() {
 }
 
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
-    const rclcpp_action::GoalUUID& uuid,
+    const rclcpp_action::GoalUUID& /*uuid*/,
     std::shared_ptr<const vortex_msgs::action::ReferenceFilterWaypoint::Goal>
-        goal) {
-    (void)uuid;
-    (void)goal;
+    /*goal*/) {
     spdlog::info("Accepted goal request");
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
 rclcpp_action::CancelResponse ReferenceFilterNode::handle_cancel(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle) {
+        vortex_msgs::action::ReferenceFilterWaypoint>> /*goal_handle*/) {
     spdlog::info("Received request to cancel goal");
-    (void)goal_handle;
     return rclcpp_action::CancelResponse::ACCEPT;
 }
 

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -94,13 +94,11 @@ void ReferenceFilterNode::set_action_server() {
     action_server_ = rclcpp_action::create_server<
         vortex_msgs::action::ReferenceFilterWaypoint>(
         this, action_server_name,
-        std::bind(&ReferenceFilterNode::handle_goal, this,
-                  std::placeholders::_1, std::placeholders::_2),
-        std::bind(&ReferenceFilterNode::handle_cancel, this,
-                  std::placeholders::_1),
-        std::bind(&ReferenceFilterNode::handle_accepted, this,
-                  std::placeholders::_1),
-        rcl_action_server_get_default_options());
+        [this](const auto& uuid, auto goal) {
+            return handle_goal(uuid, std::move(goal));
+        },
+        [this](auto goal_handle) { return handle_cancel(goal_handle); },
+        [this](auto goal_handle) { handle_accepted(goal_handle); });
 }
 
 void ReferenceFilterNode::set_refererence_filter() {
@@ -166,15 +164,13 @@ void ReferenceFilterNode::execute(
             "Using default 0.1");
     }
 
-    Waypoint wp = waypoint_from_ros(goal_handle->get_goal()->waypoint);
+    const auto wp = waypoint_from_ros(goal_handle->get_goal()->waypoint);
 
-    PoseEuler pose;
-    Twist twist;
-    {
-        std::lock_guard<std::mutex> lock(sensor_mutex_);
-        pose = current_pose_;
-        twist = current_twist_;
-    }
+    const auto [pose, twist] = [this] {
+        std::lock_guard lock(sensor_mutex_);
+        return std::pair{current_pose_, current_twist_};
+    }();
+
     follower_->start(pose, twist, wp, convergence_threshold);
 
     auto feedback = std::make_shared<
@@ -201,11 +197,10 @@ void ReferenceFilterNode::execute(
 
         Eigen::Vector18d filter_state = follower_->step();
 
-        Eigen::Vector6d current_pose_vector;
-        {
-            std::lock_guard<std::mutex> lock(sensor_mutex_);
-            current_pose_vector = current_pose_.to_vector();
-        }
+        const auto current_pose_vector = [this] {
+            std::lock_guard lock(sensor_mutex_);
+            return current_pose_.to_vector();
+        }();
 
         bool target_reached =
             follower_->within_convergance(current_pose_vector);

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -1,4 +1,4 @@
-#include "reference_filter_dp/reference_filter_ros.hpp"
+#include "reference_filter_dp/ros/reference_filter_ros.hpp"
 #include <spdlog/spdlog.h>
 #include <mutex>
 #include <rclcpp_components/register_node_macro.hpp>

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -199,15 +199,18 @@ void ReferenceFilterNode::execute(
             return;
         }
 
+        Eigen::Vector18d filter_state = follower_->step();
+
         Eigen::Vector6d current_pose_vector;
         {
             std::lock_guard<std::mutex> lock(sensor_mutex_);
             current_pose_vector = current_pose_.to_vector();
         }
 
-        StepResult step = follower_->step(current_pose_vector);
+        bool target_reached =
+            follower_->within_convergance(current_pose_vector);
 
-        if (step.target_reached) {
+        if (target_reached) {
             follower_->snap_state_to_reference();
 
             vortex_msgs::msg::ReferenceFilter final_reference_msg =
@@ -224,7 +227,7 @@ void ReferenceFilterNode::execute(
         }
 
         vortex_msgs::msg::ReferenceFilter reference_msg =
-            fill_reference_msg(step.reference_state);
+            fill_reference_msg(filter_state);
         reference_pub_->publish(reference_msg);
         feedback->reference = reference_msg;
         goal_handle->publish_feedback(feedback);

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -62,7 +62,7 @@ void ReferenceFilterNode::set_subscribers_and_publisher() {
         pose_topic, qos_sensor_data,
         [this](const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr
                    msg) {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(sensor_mutex_);
             current_pose_ =
                 vortex::utils::ros_conversions::ros_pose_to_pose_euler(
                     msg->pose.pose);
@@ -73,7 +73,7 @@ void ReferenceFilterNode::set_subscribers_and_publisher() {
         twist_topic, qos_sensor_data,
         [this](const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr
                    msg) {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(sensor_mutex_);
             current_twist_ = vortex::utils::ros_conversions::ros_twist_to_twist(
                 msg->twist.twist);
         });
@@ -133,16 +133,20 @@ rclcpp_action::CancelResponse ReferenceFilterNode::handle_cancel(
 void ReferenceFilterNode::handle_accepted(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
         vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle) {
-    const uint64_t my_generation = ++goal_generation_;
-    std::thread([this, goal_handle, my_generation]() {
-        execute(goal_handle, my_generation);
-    }).detach();
+    std::lock_guard<std::mutex> lock(execute_mutex_);
+    preempted_ = true;
+    if (execute_thread_.joinable()) {
+        execute_thread_.join();
+    }
+    preempted_ = false;
+
+    execute_thread_ =
+        std::thread([this, goal_handle]() { execute(goal_handle); });
 }
 
 void ReferenceFilterNode::execute(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle,
-    uint64_t generation) {
+        vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle) {
     spdlog::info("Executing goal");
 
     double convergence_threshold =
@@ -160,7 +164,7 @@ void ReferenceFilterNode::execute(
     PoseEuler pose;
     Twist twist;
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> lock(sensor_mutex_);
         pose = current_pose_;
         twist = current_twist_;
     }
@@ -174,15 +178,10 @@ void ReferenceFilterNode::execute(
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 
     while (rclcpp::ok()) {
-        if (generation != goal_generation_.load()) {
+        if (preempted_.load()) {
             result->success = false;
-            if (goal_handle->is_canceling()) {
-                goal_handle->canceled(result);
-                spdlog::info("Goal canceled (superseded)");
-            } else {
-                goal_handle->abort(result);
-                spdlog::info("Goal preempted by newer goal");
-            }
+            goal_handle->abort(result);
+            spdlog::info("Goal preempted by newer goal");
             return;
         }
 
@@ -195,7 +194,7 @@ void ReferenceFilterNode::execute(
 
         Eigen::Vector6d current_pose_vector;
         {
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(sensor_mutex_);
             current_pose_vector = current_pose_.to_vector();
         }
 

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -1,10 +1,10 @@
 #include "reference_filter_dp/ros/reference_filter_ros.hpp"
 #include <spdlog/spdlog.h>
-#include <mutex>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <thread>
 #include <vortex/utils/math.hpp>
 #include <vortex/utils/ros/qos_profiles.hpp>
+#include <vortex/utils/ros/ros_conversions.hpp>
 #include <vortex/utils/types.hpp>
 
 const auto start_message = R"(
@@ -55,13 +55,22 @@ void ReferenceFilterNode::set_subscribers_and_publisher() {
     pose_sub_ = this->create_subscription<
         geometry_msgs::msg::PoseWithCovarianceStamped>(
         pose_topic, qos_sensor_data,
-        std::bind(&ReferenceFilterNode::pose_callback, this,
-                  std::placeholders::_1));
+        [this](const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr
+                   msg) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            current_pose_ =
+                vortex::utils::ros_conversions::ros_pose_to_pose_euler(
+                    msg->pose.pose);
+        });
     twist_sub_ = this->create_subscription<
         geometry_msgs::msg::TwistWithCovarianceStamped>(
         twist_topic, qos_sensor_data,
-        std::bind(&ReferenceFilterNode::twist_callback, this,
-                  std::placeholders::_1));
+        [this](const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr
+                   msg) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            current_twist_ = vortex::utils::ros_conversions::ros_twist_to_twist(
+                msg->twist.twist);
+        });
 }
 
 void ReferenceFilterNode::set_action_server() {
@@ -116,18 +125,6 @@ void ReferenceFilterNode::reference_callback(
     follower_->set_reference(r_temp, mode);
 }
 
-void ReferenceFilterNode::pose_callback(
-    const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    current_pose_ = *msg;
-}
-
-void ReferenceFilterNode::twist_callback(
-    const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    current_twist_ = *msg;
-}
-
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
     const rclcpp_action::GoalUUID& uuid,
     std::shared_ptr<const vortex_msgs::action::ReferenceFilterWaypoint::Goal>
@@ -155,96 +152,16 @@ void ReferenceFilterNode::handle_accepted(
     }).detach();
 }
 
-Eigen::Vector18d ReferenceFilterNode::fill_reference_state() {
-    geometry_msgs::msg::PoseWithCovarianceStamped pose_msg;
-    geometry_msgs::msg::TwistWithCovarianceStamped twist_msg;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        pose_msg = current_pose_;
-        twist_msg = current_twist_;
-    }
-
-    Eigen::Vector18d x = Eigen::Vector18d::Zero();
-    x(0) = pose_msg.pose.pose.position.x;
-    x(1) = pose_msg.pose.pose.position.y;
-    x(2) = pose_msg.pose.pose.position.z;
-
-    const auto& o = pose_msg.pose.pose.orientation;
-    Eigen::Quaterniond q(o.w, o.x, o.y, o.z);
-    Eigen::Vector3d euler_angles = vortex::utils::math::quat_to_euler(q);
-    double roll{euler_angles(0)};
-    double pitch{euler_angles(1)};
-    double yaw{euler_angles(2)};
-
-    x(3) = vortex::utils::math::ssa(roll);
-    x(4) = vortex::utils::math::ssa(pitch);
-    x(5) = vortex::utils::math::ssa(yaw);
-
-    vortex::utils::types::PoseEuler pose{pose_msg.pose.pose.position.x,
-                                         pose_msg.pose.pose.position.y,
-                                         pose_msg.pose.pose.position.z,
-                                         roll,
-                                         pitch,
-                                         yaw};
-    Eigen::Matrix6d J = pose.as_j_matrix();
-    vortex::utils::types::Twist twist{
-        twist_msg.twist.twist.linear.x,  twist_msg.twist.twist.linear.y,
-        twist_msg.twist.twist.linear.z,  twist_msg.twist.twist.angular.x,
-        twist_msg.twist.twist.angular.y, twist_msg.twist.twist.angular.z};
-    Eigen::Vector6d pose_dot = J * twist.to_vector();
-
-    x(6) = pose_dot(0);
-    x(7) = pose_dot(1);
-    x(8) = pose_dot(2);
-    x(9) = pose_dot(3);
-    x(10) = pose_dot(4);
-    x(11) = pose_dot(5);
-
-    return x;
-}
-
 Eigen::Vector6d ReferenceFilterNode::measured_pose_vector6() {
-    geometry_msgs::msg::PoseWithCovarianceStamped pose_msg;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        pose_msg = current_pose_;
-    }
-
-    const auto& p = pose_msg.pose.pose.position;
-    const auto& o = pose_msg.pose.pose.orientation;
-
-    Eigen::Quaterniond q(o.w, o.x, o.y, o.z);
-    if (q.norm() < 1e-9) {
-        q = Eigen::Quaterniond::Identity();
-    } else {
-        q.normalize();
-    }
-
-    Eigen::Vector3d euler = vortex::utils::math::quat_to_euler(q);
-
-    Eigen::Vector6d y;
-    y << p.x, p.y, p.z, vortex::utils::math::ssa(euler(0)),
-        vortex::utils::math::ssa(euler(1)), vortex::utils::math::ssa(euler(2));
-    return y;
+    std::lock_guard<std::mutex> lock(mutex_);
+    vortex::utils::types::PoseEuler pose = current_pose_;
+    pose.apply_ssa();
+    return pose.to_vector();
 }
 
-Eigen::Vector6d ReferenceFilterNode::fill_reference_goal(
+vortex::utils::types::PoseEuler ReferenceFilterNode::fill_reference_goal(
     const geometry_msgs::msg::Pose& goal) {
-    double x{goal.position.x};
-    double y{goal.position.y};
-    double z{goal.position.z};
-
-    const auto& o = goal.orientation;
-    Eigen::Quaterniond q(o.w, o.x, o.y, o.z);
-    Eigen::Vector3d euler_angles = vortex::utils::math::quat_to_euler(q);
-    double roll{euler_angles(0)};
-    double pitch{euler_angles(1)};
-    double yaw{euler_angles(2)};
-
-    Eigen::Vector6d r;
-    r << x, y, z, roll, pitch, yaw;
-
-    return r;
+    return vortex::utils::ros_conversions::ros_pose_to_pose_euler(goal);
 }
 
 vortex_msgs::msg::ReferenceFilter ReferenceFilterNode::fill_reference_msg() {
@@ -272,8 +189,6 @@ void ReferenceFilterNode::execute(
     uint64_t generation) {
     spdlog::info("Executing goal");
 
-    Eigen::Vector18d initial_state = fill_reference_state();
-
     const geometry_msgs::msg::Pose goal =
         goal_handle->get_goal()->waypoint.pose;
     uint8_t mode = goal_handle->get_goal()->waypoint.mode;
@@ -287,13 +202,20 @@ void ReferenceFilterNode::execute(
             "Using default 0.1");
     }
 
-    Eigen::Vector6d r_temp = fill_reference_goal(goal);
     active_mode_ = mode;
 
     Waypoint wp;
-    wp.pose = r_temp;
+    wp.pose = fill_reference_goal(goal);
     wp.mode = static_cast<WaypointMode>(mode);
-    follower_->start(initial_state, wp, convergence_threshold);
+
+    PoseEuler pose;
+    Twist twist;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        pose = current_pose_;
+        twist = current_twist_;
+    }
+    follower_->start(pose, twist, wp, convergence_threshold);
 
     auto feedback = std::make_shared<
         vortex_msgs::action::ReferenceFilterWaypoint::Feedback>();

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -20,7 +20,8 @@ namespace vortex::guidance {
 
 ReferenceFilterNode::ReferenceFilterNode(const rclcpp::NodeOptions& options)
     : Node("reference_filter_node", options) {
-    time_step_ = std::chrono::milliseconds(10);
+    int time_step_ms = this->declare_parameter<int>("time_step_ms");
+    time_step_ = std::chrono::milliseconds(time_step_ms);
 
     set_subscribers_and_publisher();
 

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -201,25 +201,27 @@ void ReferenceFilterNode::execute(
 
         StepResult step = follower_->step(current_pose_vector);
 
-        vortex_msgs::msg::ReferenceFilter reference_msg =
-            fill_reference_msg(follower_->state());
+        if (step.target_reached) {
+            follower_->snap_state_to_reference();
 
-        feedback->reference = reference_msg;
+            vortex_msgs::msg::ReferenceFilter final_reference_msg =
+                fill_reference_msg(follower_->state());
 
-        goal_handle->publish_feedback(feedback);
-        reference_pub_->publish(reference_msg);
+            feedback->reference = final_reference_msg;
+            goal_handle->publish_feedback(feedback);
+            reference_pub_->publish(final_reference_msg);
 
-        if (step.converged) {
             result->success = true;
             goal_handle->succeed(result);
-            follower_->snap_state_to_reference();
-            vortex_msgs::msg::ReferenceFilter feedback_msg =
-                fill_reference_msg(follower_->state());
-            reference_pub_->publish(feedback_msg);
             spdlog::info("Goal reached");
             return;
         }
 
+        vortex_msgs::msg::ReferenceFilter reference_msg =
+            fill_reference_msg(step.reference_state);
+        reference_pub_->publish(reference_msg);
+        feedback->reference = reference_msg;
+        goal_handle->publish_feedback(feedback);
         loop_rate.sleep();
     }
     if (!rclcpp::ok() && goal_handle->is_active()) {

--- a/guidance/reference_filter_dp/test/CMakeLists.txt
+++ b/guidance/reference_filter_dp/test/CMakeLists.txt
@@ -19,3 +19,39 @@ target_link_libraries(
 ament_target_dependencies(${TEST_BINARY_NAME} PUBLIC Eigen3)
 
 gtest_discover_tests(${TEST_BINARY_NAME})
+
+# Waypoint utils tests
+set(TEST_WAYPOINT_UTILS ${PROJECT_NAME}_test_waypoint_utils)
+add_executable(
+    ${TEST_WAYPOINT_UTILS}
+    test_waypoint_utils.cpp
+)
+
+target_link_libraries(
+    ${TEST_WAYPOINT_UTILS}
+    PRIVATE
+    ${CORE_LIB_NAME}
+    GTest::GTest
+)
+
+ament_target_dependencies(${TEST_WAYPOINT_UTILS} PUBLIC Eigen3 vortex_utils)
+
+gtest_discover_tests(${TEST_WAYPOINT_UTILS})
+
+# Waypoint follower tests
+set(TEST_WAYPOINT_FOLLOWER ${PROJECT_NAME}_test_waypoint_follower)
+add_executable(
+    ${TEST_WAYPOINT_FOLLOWER}
+    test_waypoint_follower.cpp
+)
+
+target_link_libraries(
+    ${TEST_WAYPOINT_FOLLOWER}
+    PRIVATE
+    ${CORE_LIB_NAME}
+    GTest::GTest
+)
+
+ament_target_dependencies(${TEST_WAYPOINT_FOLLOWER} PUBLIC Eigen3 vortex_utils)
+
+gtest_discover_tests(${TEST_WAYPOINT_FOLLOWER})

--- a/guidance/reference_filter_dp/test/CMakeLists.txt
+++ b/guidance/reference_filter_dp/test/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(
 target_link_libraries(
     ${TEST_BINARY_NAME}
     PRIVATE
-    ${LIB_NAME}
+    ${CORE_LIB_NAME}
     GTest::GTest
 )
 

--- a/guidance/reference_filter_dp/test/test_reference_filter.cpp
+++ b/guidance/reference_filter_dp/test/test_reference_filter.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include "reference_filter_dp/eigen_typedefs.hpp"
-#include "reference_filter_dp/reference_filter.hpp"
+#include "reference_filter_dp/lib/eigen_typedefs.hpp"
+#include "reference_filter_dp/lib/reference_filter.hpp"
 
 namespace vortex::guidance {
 

--- a/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+#include "reference_filter_dp/lib/waypoint_follower.hpp"
+#include "reference_filter_dp/lib/waypoint_utils.hpp"
+
+namespace vortex::guidance {
+
+class WaypointFollowerTests : public ::testing::Test {
+   protected:
+    ReferenceFilterParams get_params() {
+        ReferenceFilterParams params;
+        params.omega = Eigen::Vector6d::Ones();
+        params.zeta = Eigen::Vector6d::Ones();
+        return params;
+    }
+};
+
+TEST_F(WaypointFollowerTests, StartAndStepConverges) {
+    WaypointFollower follower(get_params(), 0.01);
+
+    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
+    Waypoint wp;
+    wp.pose << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    wp.mode = WaypointMode::FULL_POSE;
+
+    follower.start(initial_state, wp, 0.1);
+
+    // Simulate the measured pose being at the reference
+    Eigen::Vector6d measured_at_ref;
+    measured_at_ref << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+
+    StepResult result = follower.step(measured_at_ref);
+
+    EXPECT_TRUE(result.converged);
+    EXPECT_EQ(result.state.size(), 18);
+}
+
+TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
+    WaypointFollower follower(get_params(), 0.01);
+
+    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
+    Waypoint wp;
+    wp.pose << 10.0, 10.0, 0.0, 0.0, 0.0, 0.0;
+    wp.mode = WaypointMode::FULL_POSE;
+
+    follower.start(initial_state, wp, 0.1);
+
+    Eigen::Vector6d measured_far = Eigen::Vector6d::Zero();
+    StepResult result = follower.step(measured_far);
+
+    EXPECT_FALSE(result.converged);
+}
+
+TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {
+    WaypointFollower follower(get_params(), 0.01);
+
+    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
+    Waypoint wp;
+    wp.pose << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    wp.mode = WaypointMode::FULL_POSE;
+
+    follower.start(initial_state, wp, 0.1);
+
+    Eigen::Vector6d new_ref;
+    new_ref << 5.0, 5.0, 0.0, 0.0, 0.0, 0.0;
+    follower.set_reference(new_ref, WaypointMode::FULL_POSE);
+
+    EXPECT_DOUBLE_EQ(follower.reference()(0), 5.0);
+    EXPECT_DOUBLE_EQ(follower.reference()(1), 5.0);
+}
+
+TEST_F(WaypointFollowerTests, SnapStateToReference) {
+    WaypointFollower follower(get_params(), 0.01);
+
+    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
+    Waypoint wp;
+    wp.pose << 3.0, 4.0, 5.0, 0.1, 0.2, 0.3;
+    wp.mode = WaypointMode::FULL_POSE;
+
+    follower.start(initial_state, wp, 0.1);
+    follower.snap_state_to_reference();
+
+    const Eigen::Vector18d& state = follower.state();
+    const Eigen::Vector6d& ref = follower.reference();
+
+    for (int i = 0; i < 6; ++i) {
+        EXPECT_DOUBLE_EQ(state(i), ref(i));
+    }
+}
+
+TEST_F(WaypointFollowerTests, StateEvolvesWithStep) {
+    WaypointFollower follower(get_params(), 0.01);
+
+    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
+    Waypoint wp;
+    wp.pose << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    wp.mode = WaypointMode::FULL_POSE;
+
+    follower.start(initial_state, wp, 0.1);
+
+    Eigen::Vector6d measured = Eigen::Vector6d::Zero();
+
+    // Run several steps — state should move toward reference
+    for (int i = 0; i < 100; ++i) {
+        follower.step(measured);
+    }
+
+    // x position should have moved toward 1.0
+    EXPECT_GT(follower.state()(0), 0.0);
+}
+
+}  // namespace vortex::guidance
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
@@ -26,14 +26,14 @@ TEST_F(WaypointFollowerTests, StartAndStepConverges) {
 
     follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
+    Eigen::Vector18d state = follower.step();
+
     // Simulate the measured pose being at the reference
     Eigen::Vector6d measured_at_ref;
     measured_at_ref << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
-    StepResult result = follower.step(measured_at_ref);
-
-    EXPECT_TRUE(result.target_reached);
-    EXPECT_EQ(result.reference_state.size(), 18);
+    EXPECT_TRUE(follower.within_convergance(measured_at_ref));
+    EXPECT_EQ(state.size(), 18);
 }
 
 TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
@@ -45,10 +45,10 @@ TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
 
     follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
-    Eigen::Vector6d measured_far = Eigen::Vector6d::Zero();
-    StepResult result = follower.step(measured_far);
+    follower.step();
 
-    EXPECT_FALSE(result.target_reached);
+    Eigen::Vector6d measured_far = Eigen::Vector6d::Zero();
+    EXPECT_FALSE(follower.within_convergance(measured_far));
 }
 
 TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {
@@ -94,11 +94,9 @@ TEST_F(WaypointFollowerTests, StateEvolvesWithStep) {
 
     follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
-    Eigen::Vector6d measured = Eigen::Vector6d::Zero();
-
     // Run several steps — state should move toward reference
     for (int i = 0; i < 100; ++i) {
-        follower.step(measured);
+        follower.step();
     }
 
     // x position should have moved toward 1.0

--- a/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
@@ -32,8 +32,8 @@ TEST_F(WaypointFollowerTests, StartAndStepConverges) {
 
     StepResult result = follower.step(measured_at_ref);
 
-    EXPECT_TRUE(result.converged);
-    EXPECT_EQ(result.state.size(), 18);
+    EXPECT_TRUE(result.target_reached);
+    EXPECT_EQ(result.reference_state.size(), 18);
 }
 
 TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
@@ -48,7 +48,7 @@ TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
     Eigen::Vector6d measured_far = Eigen::Vector6d::Zero();
     StepResult result = follower.step(measured_far);
 
-    EXPECT_FALSE(result.converged);
+    EXPECT_FALSE(result.target_reached);
 }
 
 TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {

--- a/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
@@ -12,17 +12,19 @@ class WaypointFollowerTests : public ::testing::Test {
         params.zeta = Eigen::Vector6d::Ones();
         return params;
     }
+
+    PoseEuler zero_pose() { return PoseEuler{}; }
+    Twist zero_twist() { return Twist{}; }
 };
 
 TEST_F(WaypointFollowerTests, StartAndStepConverges) {
     WaypointFollower follower(get_params(), 0.01);
 
-    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
     Waypoint wp;
-    wp.pose << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    wp.pose = PoseEuler{1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     wp.mode = WaypointMode::FULL_POSE;
 
-    follower.start(initial_state, wp, 0.1);
+    follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
     // Simulate the measured pose being at the reference
     Eigen::Vector6d measured_at_ref;
@@ -37,12 +39,11 @@ TEST_F(WaypointFollowerTests, StartAndStepConverges) {
 TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
     WaypointFollower follower(get_params(), 0.01);
 
-    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
     Waypoint wp;
-    wp.pose << 10.0, 10.0, 0.0, 0.0, 0.0, 0.0;
+    wp.pose = PoseEuler{10.0, 10.0, 0.0, 0.0, 0.0, 0.0};
     wp.mode = WaypointMode::FULL_POSE;
 
-    follower.start(initial_state, wp, 0.1);
+    follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
     Eigen::Vector6d measured_far = Eigen::Vector6d::Zero();
     StepResult result = follower.step(measured_far);
@@ -53,12 +54,11 @@ TEST_F(WaypointFollowerTests, StepDoesNotConvergeWhenFar) {
 TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {
     WaypointFollower follower(get_params(), 0.01);
 
-    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
     Waypoint wp;
-    wp.pose << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    wp.pose = PoseEuler{1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     wp.mode = WaypointMode::FULL_POSE;
 
-    follower.start(initial_state, wp, 0.1);
+    follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
     Eigen::Vector6d new_ref;
     new_ref << 5.0, 5.0, 0.0, 0.0, 0.0, 0.0;
@@ -71,12 +71,11 @@ TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {
 TEST_F(WaypointFollowerTests, SnapStateToReference) {
     WaypointFollower follower(get_params(), 0.01);
 
-    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
     Waypoint wp;
-    wp.pose << 3.0, 4.0, 5.0, 0.1, 0.2, 0.3;
+    wp.pose = PoseEuler{3.0, 4.0, 5.0, 0.1, 0.2, 0.3};
     wp.mode = WaypointMode::FULL_POSE;
 
-    follower.start(initial_state, wp, 0.1);
+    follower.start(zero_pose(), zero_twist(), wp, 0.1);
     follower.snap_state_to_reference();
 
     const Eigen::Vector18d& state = follower.state();
@@ -90,12 +89,11 @@ TEST_F(WaypointFollowerTests, SnapStateToReference) {
 TEST_F(WaypointFollowerTests, StateEvolvesWithStep) {
     WaypointFollower follower(get_params(), 0.01);
 
-    Eigen::Vector18d initial_state = Eigen::Vector18d::Zero();
     Waypoint wp;
-    wp.pose << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    wp.pose = PoseEuler{1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     wp.mode = WaypointMode::FULL_POSE;
 
-    follower.start(initial_state, wp, 0.1);
+    follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
     Eigen::Vector6d measured = Eigen::Vector6d::Zero();
 

--- a/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
@@ -60,8 +60,7 @@ TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {
 
     follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
-    Eigen::Vector6d new_ref;
-    new_ref << 5.0, 5.0, 0.0, 0.0, 0.0, 0.0;
+    PoseEuler new_ref{5.0, 5.0, 0.0, 0.0, 0.0, 0.0};
     follower.set_reference(new_ref, WaypointMode::FULL_POSE);
 
     EXPECT_DOUBLE_EQ(follower.reference()(0), 5.0);

--- a/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_follower.cpp
@@ -61,7 +61,7 @@ TEST_F(WaypointFollowerTests, SetReferenceUpdatesMidSequence) {
     follower.start(zero_pose(), zero_twist(), wp, 0.1);
 
     PoseEuler new_ref{5.0, 5.0, 0.0, 0.0, 0.0, 0.0};
-    follower.set_reference(new_ref, WaypointMode::FULL_POSE);
+    follower.set_reference(new_ref);
 
     EXPECT_DOUBLE_EQ(follower.reference()(0), 5.0);
     EXPECT_DOUBLE_EQ(follower.reference()(1), 5.0);
@@ -77,8 +77,8 @@ TEST_F(WaypointFollowerTests, SnapStateToReference) {
     follower.start(zero_pose(), zero_twist(), wp, 0.1);
     follower.snap_state_to_reference();
 
-    const Eigen::Vector18d& state = follower.state();
-    const Eigen::Vector6d& ref = follower.reference();
+    Eigen::Vector18d state = follower.state();
+    Eigen::Vector6d ref = follower.reference();
 
     for (int i = 0; i < 6; ++i) {
         EXPECT_DOUBLE_EQ(state(i), ref(i));

--- a/guidance/reference_filter_dp/test/test_waypoint_utils.cpp
+++ b/guidance/reference_filter_dp/test/test_waypoint_utils.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include "reference_filter_dp/lib/waypoint_utils.hpp"
+
+namespace vortex::guidance {
+
+// --- apply_mode_logic tests ---
+
+TEST(ApplyModeLogic, FullPoseReturnsInputUnchanged) {
+    Eigen::Vector6d r_in;
+    r_in << 1.0, 2.0, 3.0, 0.1, 0.2, 0.3;
+    Eigen::Vector6d state = Eigen::Vector6d::Zero();
+
+    Eigen::Vector6d result =
+        apply_mode_logic(r_in, WaypointMode::FULL_POSE, state);
+
+    for (int i = 0; i < 6; ++i) {
+        EXPECT_DOUBLE_EQ(result(i), r_in(i));
+    }
+}
+
+TEST(ApplyModeLogic, OnlyPositionKeepsOrientationFromState) {
+    Eigen::Vector6d r_in;
+    r_in << 1.0, 2.0, 3.0, 0.1, 0.2, 0.3;
+    Eigen::Vector6d state;
+    state << 10.0, 20.0, 30.0, 0.4, 0.5, 0.6;
+
+    Eigen::Vector6d result =
+        apply_mode_logic(r_in, WaypointMode::ONLY_POSITION, state);
+
+    EXPECT_DOUBLE_EQ(result(0), 1.0);
+    EXPECT_DOUBLE_EQ(result(1), 2.0);
+    EXPECT_DOUBLE_EQ(result(2), 3.0);
+    EXPECT_DOUBLE_EQ(result(3), 0.4);
+    EXPECT_DOUBLE_EQ(result(4), 0.5);
+    EXPECT_DOUBLE_EQ(result(5), 0.6);
+}
+
+TEST(ApplyModeLogic, ForwardHeadingComputesYawFromDelta) {
+    Eigen::Vector6d r_in;
+    r_in << 1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+    Eigen::Vector6d state = Eigen::Vector6d::Zero();
+
+    Eigen::Vector6d result =
+        apply_mode_logic(r_in, WaypointMode::FORWARD_HEADING, state);
+
+    double expected_yaw = std::atan2(1.0, 1.0);  // pi/4
+    EXPECT_DOUBLE_EQ(result(0), 1.0);
+    EXPECT_DOUBLE_EQ(result(1), 1.0);
+    EXPECT_DOUBLE_EQ(result(3), 0.0);
+    EXPECT_DOUBLE_EQ(result(4), 0.0);
+    EXPECT_NEAR(result(5), expected_yaw, 1e-12);
+}
+
+TEST(ApplyModeLogic, OnlyOrientationKeepsPositionFromState) {
+    Eigen::Vector6d r_in;
+    r_in << 1.0, 2.0, 3.0, 0.1, 0.2, 0.3;
+    Eigen::Vector6d state;
+    state << 10.0, 20.0, 30.0, 0.4, 0.5, 0.6;
+
+    Eigen::Vector6d result =
+        apply_mode_logic(r_in, WaypointMode::ONLY_ORIENTATION, state);
+
+    EXPECT_DOUBLE_EQ(result(0), 10.0);
+    EXPECT_DOUBLE_EQ(result(1), 20.0);
+    EXPECT_DOUBLE_EQ(result(2), 30.0);
+    EXPECT_DOUBLE_EQ(result(3), 0.1);
+    EXPECT_DOUBLE_EQ(result(4), 0.2);
+    EXPECT_DOUBLE_EQ(result(5), 0.3);
+}
+
+// --- has_converged tests ---
+
+TEST(HasConverged, FullPoseBelowThreshold) {
+    Eigen::Vector6d measured;
+    measured << 1.0, 2.0, 3.0, 0.1, 0.2, 0.3;
+    Eigen::Vector6d reference = measured;
+    reference(0) += 0.001;
+
+    EXPECT_TRUE(
+        has_converged(measured, reference, WaypointMode::FULL_POSE, 0.1));
+}
+
+TEST(HasConverged, FullPoseAboveThreshold) {
+    Eigen::Vector6d measured = Eigen::Vector6d::Zero();
+    Eigen::Vector6d reference;
+    reference << 1.0, 1.0, 1.0, 0.0, 0.0, 0.0;
+
+    EXPECT_FALSE(
+        has_converged(measured, reference, WaypointMode::FULL_POSE, 0.1));
+}
+
+TEST(HasConverged, OnlyPositionIgnoresOrientation) {
+    Eigen::Vector6d measured;
+    measured << 1.0, 2.0, 3.0, 0.0, 0.0, 0.0;
+    Eigen::Vector6d reference;
+    reference << 1.0, 2.0, 3.0, 1.0, 1.0, 1.0;
+
+    EXPECT_TRUE(
+        has_converged(measured, reference, WaypointMode::ONLY_POSITION, 0.1));
+}
+
+TEST(HasConverged, OnlyOrientationIgnoresPosition) {
+    Eigen::Vector6d measured;
+    measured << 100.0, 200.0, 300.0, 0.1, 0.2, 0.3;
+    Eigen::Vector6d reference;
+    reference << 0.0, 0.0, 0.0, 0.1, 0.2, 0.3;
+
+    EXPECT_TRUE(has_converged(measured, reference,
+                              WaypointMode::ONLY_ORIENTATION, 0.1));
+}
+
+TEST(HasConverged, ForwardHeadingUsesPositionAndYawOnly) {
+    Eigen::Vector6d measured;
+    measured << 1.0, 2.0, 3.0, 0.5, 0.5, 0.1;
+    Eigen::Vector6d reference;
+    reference << 1.0, 2.0, 3.0, 0.0, 0.0, 0.1;
+
+    // Roll and pitch differ but should be ignored
+    EXPECT_TRUE(
+        has_converged(measured, reference, WaypointMode::FORWARD_HEADING, 0.1));
+}
+
+}  // namespace vortex::guidance
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Restructured the package into a standalone core library (`lib/`) and a ROS integration layer (`ros/`)
- Extracted waypoint following, mode logic, and convergence checking out of the ROS node
- Fixed action server concurrency race: replaced detached threads + generation counter with a join-before-spawn model guarded by `execute_mutex_`, ensuring only one thread accesses the follower at a time

