### PR TITLE
supress verbose pre-commit output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
       - id: ament_cpplint
         name: ament_cpplint
         description: Static code analysis of C/C++ files.
-        entry: ament_cpplint
+        entry: bash -c 'out=$(ament_cpplint "$@" 2>&1); rc=$?; printf "%s\n" "$out" | grep -Ev "^Using|Done processing|No problems found"; exit $rc' --
         language: system
         files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
         args: [


### PR DESCRIPTION
Done processing                                                                                   
  /home/jorgen/ros2_ws/src/vortex-auv/mission/landmark_server/src/landmark_server_convergence.cpp   
                                                                                                    
  Using '--root=/home/jorgen/ros2_ws/src/vortex-auv/mission/pipeline/pipeline_fsm/src' argument     
                                                                                                    
  Done processing                                                                                   
  /home/jorgen/ros2_ws/src/vortex-auv/mission/pipeline/pipeline_fsm/src/pipeline_fsm.cpp            
                                                                                                    
  Using '--root=/home/jorgen/ros2_ws/src/vortex-auv/motion/thrust_allocator_auv/src' argument   
  
  
  This output is supressed when pre-commit fails