### PR TITLE
Refactor: All Guidance will use same action type

### DIFF
--- a/filtering/pose_filtering/include/pose_filtering/lib/pose_track_manager.hpp
+++ b/filtering/pose_filtering/include/pose_filtering/lib/pose_track_manager.hpp
@@ -15,7 +15,7 @@ namespace vortex::filtering {
  * The PoseTrackManager implements track creation, confirmation,
  * deletion and update logic using a PDAF filter for each track with
  * N/M logic for track lifecycle management. It handles spatial and
- * angular gating for associating pose measurements to existing tracks.
+ * angular gating for associating pose measurements to existing tracks..
  */
 
 /**

--- a/filtering/pose_filtering/include/pose_filtering/lib/pose_track_manager.hpp
+++ b/filtering/pose_filtering/include/pose_filtering/lib/pose_track_manager.hpp
@@ -15,7 +15,7 @@ namespace vortex::filtering {
  * The PoseTrackManager implements track creation, confirmation,
  * deletion and update logic using a PDAF filter for each track with
  * N/M logic for track lifecycle management. It handles spatial and
- * angular gating for associating pose measurements to existing tracks..
+ * angular gating for associating pose measurements to existing tracks.
  */
 
 /**

--- a/guidance/los_guidance/include/los_guidance/los_guidance_ros.hpp
+++ b/guidance/los_guidance/include/los_guidance/los_guidance_ros.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
-#include <vortex_msgs/action/los_guidance.hpp>
+#include <vortex_msgs/action/set_waypoint.hpp>
 #include <vortex_msgs/msg/los_guidance.hpp>
 #include <vortex_msgs/msg/waypoints.hpp>
 #include "los_guidance.hpp"
@@ -31,8 +31,7 @@ class LOSGuidanceNode : public rclcpp::Node {
 
     // @brief Callback for the waypoint topic
     // @param msg The reference message
-    void waypoint_callback(
-        const geometry_msgs::msg::PointStamped::SharedPtr msg);
+    void waypoint_callback(const geometry_msgs::msg::Point::SharedPtr msg);
 
     // @brief Callback for the pose topic
     // @param msg The pose message
@@ -45,40 +44,38 @@ class LOSGuidanceNode : public rclcpp::Node {
     // @return The goal response
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
-        std::shared_ptr<const vortex_msgs::action::LOSGuidance::Goal> goal);
+        std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal);
 
     // @brief Handle the cancel request
     // @param goal_handle The goal handle
     // @return The cancel response
     rclcpp_action::CancelResponse handle_cancel(
         const std::shared_ptr<
-            rclcpp_action::ServerGoalHandle<vortex_msgs::action::LOSGuidance>>
+            rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
             goal_handle);
 
     // @brief Handle the accepted request
     // @param goal_handle The goal handle
     void handle_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                             vortex_msgs::action::LOSGuidance>> goal_handle);
+                             vortex_msgs::action::SetWaypoint>> goal_handle);
 
     // @brief Execute the goal
     // @param goal_handle The goal handle
     void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                     vortex_msgs::action::LOSGuidance>> goal_handle);
+                     vortex_msgs::action::SetWaypoint>> goal_handle);
 
     // @brief Fill the lost waypoints
     // @param goal The goal message
-    void fill_los_waypoints(
-        const geometry_msgs::msg::PointStamped& los_waypoint);
+    void fill_los_waypoints(const geometry_msgs::msg::Point& los_waypoint);
 
     vortex_msgs::msg::LOSGuidance fill_los_reference();
 
-    rclcpp_action::Server<vortex_msgs::action::LOSGuidance>::SharedPtr
+    rclcpp_action::Server<vortex_msgs::action::SetWaypoint>::SharedPtr
         action_server_;
 
     rclcpp::Publisher<vortex_msgs::msg::LOSGuidance>::SharedPtr reference_pub_;
 
-    rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr
-        waypoint_sub_;
+    rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr waypoint_sub_;
 
     rclcpp::Subscription<
         geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_sub_;
@@ -92,7 +89,7 @@ class LOSGuidanceNode : public rclcpp::Node {
     rclcpp_action::GoalUUID preempted_goal_id_;
 
     std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::LOSGuidance>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
         goal_handle_;
 
     rclcpp::CallbackGroup::SharedPtr cb_group_;

--- a/guidance/los_guidance/include/los_guidance/los_guidance_ros.hpp
+++ b/guidance/los_guidance/include/los_guidance/los_guidance_ros.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
-#include <vortex_msgs/action/set_waypoint.hpp>
+#include <vortex_msgs/action/guidance_waypoint.hpp>
 #include <vortex_msgs/msg/los_guidance.hpp>
 #include <vortex_msgs/msg/waypoints.hpp>
 #include "los_guidance.hpp"
@@ -44,25 +44,26 @@ class LOSGuidanceNode : public rclcpp::Node {
     // @return The goal response
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
-        std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal);
+        std::shared_ptr<const vortex_msgs::action::GuidanceWaypoint::Goal>
+            goal);
 
     // @brief Handle the cancel request
     // @param goal_handle The goal handle
     // @return The cancel response
     rclcpp_action::CancelResponse handle_cancel(
-        const std::shared_ptr<
-            rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
-            goal_handle);
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     // @brief Handle the accepted request
     // @param goal_handle The goal handle
-    void handle_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                             vortex_msgs::action::SetWaypoint>> goal_handle);
+    void handle_accepted(
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     // @brief Execute the goal
     // @param goal_handle The goal handle
     void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                     vortex_msgs::action::SetWaypoint>> goal_handle);
+                     vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     // @brief Fill the lost waypoints
     // @param goal The goal message
@@ -70,7 +71,7 @@ class LOSGuidanceNode : public rclcpp::Node {
 
     vortex_msgs::msg::LOSGuidance fill_los_reference();
 
-    rclcpp_action::Server<vortex_msgs::action::SetWaypoint>::SharedPtr
+    rclcpp_action::Server<vortex_msgs::action::GuidanceWaypoint>::SharedPtr
         action_server_;
 
     rclcpp::Publisher<vortex_msgs::msg::LOSGuidance>::SharedPtr reference_pub_;
@@ -89,7 +90,7 @@ class LOSGuidanceNode : public rclcpp::Node {
     rclcpp_action::GoalUUID preempted_goal_id_;
 
     std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle_;
 
     rclcpp::CallbackGroup::SharedPtr cb_group_;

--- a/guidance/los_guidance/src/los_guidance_ros.cpp
+++ b/guidance/los_guidance/src/los_guidance_ros.cpp
@@ -62,7 +62,7 @@ void LOSGuidanceNode::set_action_server() {
         this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
     action_server_ =
-        rclcpp_action::create_server<vortex_msgs::action::SetWaypoint>(
+        rclcpp_action::create_server<vortex_msgs::action::GuidanceWaypoint>(
             this, action_server_name,
             std::bind(&LOSGuidanceNode::handle_goal, this,
                       std::placeholders::_1, std::placeholders::_2),
@@ -111,7 +111,7 @@ void LOSGuidanceNode::pose_callback(
 
 rclcpp_action::GoalResponse LOSGuidanceNode::handle_goal(
     const rclcpp_action::GoalUUID&,
-    std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal) {
+    std::shared_ptr<const vortex_msgs::action::GuidanceWaypoint::Goal> goal) {
     (void)goal;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -128,7 +128,7 @@ rclcpp_action::GoalResponse LOSGuidanceNode::handle_goal(
 
 rclcpp_action::CancelResponse LOSGuidanceNode::handle_cancel(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     spdlog::info("Received request to cancel goal");
     (void)goal_handle;
@@ -137,7 +137,7 @@ rclcpp_action::CancelResponse LOSGuidanceNode::handle_cancel(
 
 void LOSGuidanceNode::handle_accepted(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     execute(goal_handle);
 }
@@ -164,7 +164,7 @@ vortex_msgs::msg::LOSGuidance LOSGuidanceNode::fill_los_reference() {
 
 void LOSGuidanceNode::execute(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -183,7 +183,8 @@ void LOSGuidanceNode::execute(
 
     adaptive_los_guidance_->update_angles(last_point_, next_point_);
 
-    auto result = std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
+    auto result =
+        std::make_shared<vortex_msgs::action::GuidanceWaypoint::Result>();
 
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 

--- a/guidance/los_guidance/src/los_guidance_ros.cpp
+++ b/guidance/los_guidance/src/los_guidance_ros.cpp
@@ -1,5 +1,6 @@
 #include "los_guidance/los_guidance_ros.hpp"
 #include <spdlog/spdlog.h>
+#include <geometry_msgs/msg/detail/point_stamped__struct.hpp>
 #include <vortex/utils/ros/qos_profiles.hpp>
 
 const auto start_message = R"(
@@ -41,7 +42,7 @@ void LOSGuidanceNode::set_subscribers_and_publisher() {
     reference_pub_ = this->create_publisher<vortex_msgs::msg::LOSGuidance>(
         guidance_topic, qos_sensor_data);
 
-    waypoint_sub_ = this->create_subscription<geometry_msgs::msg::PointStamped>(
+    waypoint_sub_ = this->create_subscription<geometry_msgs::msg::Point>(
         waypoint_topic, qos_sensor_data,
         std::bind(&LOSGuidanceNode::waypoint_callback, this,
                   std::placeholders::_1));
@@ -61,7 +62,7 @@ void LOSGuidanceNode::set_action_server() {
         this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
     action_server_ =
-        rclcpp_action::create_server<vortex_msgs::action::LOSGuidance>(
+        rclcpp_action::create_server<vortex_msgs::action::SetWaypoint>(
             this, action_server_name,
             std::bind(&LOSGuidanceNode::handle_goal, this,
                       std::placeholders::_1, std::placeholders::_2),
@@ -94,7 +95,7 @@ void LOSGuidanceNode::set_adaptive_los_guidance() {
 }
 
 void LOSGuidanceNode::waypoint_callback(
-    const geometry_msgs::msg::PointStamped::SharedPtr los_waypoint) {
+    const geometry_msgs::msg::Point::SharedPtr los_waypoint) {
     fill_los_waypoints(*los_waypoint);
     adaptive_los_guidance_->update_angles(last_point_, next_point_);
     spdlog::info("Received waypoint");
@@ -110,7 +111,7 @@ void LOSGuidanceNode::pose_callback(
 
 rclcpp_action::GoalResponse LOSGuidanceNode::handle_goal(
     const rclcpp_action::GoalUUID&,
-    std::shared_ptr<const vortex_msgs::action::LOSGuidance::Goal> goal) {
+    std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal) {
     (void)goal;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -127,7 +128,7 @@ rclcpp_action::GoalResponse LOSGuidanceNode::handle_goal(
 
 rclcpp_action::CancelResponse LOSGuidanceNode::handle_cancel(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::LOSGuidance>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
         goal_handle) {
     spdlog::info("Received request to cancel goal");
     (void)goal_handle;
@@ -136,20 +137,20 @@ rclcpp_action::CancelResponse LOSGuidanceNode::handle_cancel(
 
 void LOSGuidanceNode::handle_accepted(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::LOSGuidance>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
         goal_handle) {
     execute(goal_handle);
 }
 
 void LOSGuidanceNode::fill_los_waypoints(
-    const geometry_msgs::msg::PointStamped& los_waypoint) {
+    const geometry_msgs::msg::Point& los_waypoint) {
     last_point_.x = eta_.x;
     last_point_.y = eta_.y;
     last_point_.z = eta_.z;
 
-    next_point_.x = los_waypoint.point.x;
-    next_point_.y = los_waypoint.point.y;
-    next_point_.z = los_waypoint.point.z;
+    next_point_.x = los_waypoint.x;
+    next_point_.y = los_waypoint.y;
+    next_point_.z = los_waypoint.z;
 }
 
 vortex_msgs::msg::LOSGuidance LOSGuidanceNode::fill_los_reference() {
@@ -163,7 +164,7 @@ vortex_msgs::msg::LOSGuidance LOSGuidanceNode::fill_los_reference() {
 
 void LOSGuidanceNode::execute(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::LOSGuidance>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
         goal_handle) {
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -175,14 +176,14 @@ void LOSGuidanceNode::execute(
 
     spdlog::info("Executing goal");
 
-    const geometry_msgs::msg::PointStamped los_waypoint =
-        goal_handle->get_goal()->goal;
+    const geometry_msgs::msg::Point los_waypoint =
+        goal_handle->get_goal()->waypoint.pose.position;
 
     fill_los_waypoints(los_waypoint);
 
     adaptive_los_guidance_->update_angles(last_point_, next_point_);
 
-    auto result = std::make_shared<vortex_msgs::action::LOSGuidance::Result>();
+    auto result = std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
 
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -9,7 +9,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <vortex/utils/types.hpp>
-#include <vortex_msgs/action/set_waypoint.hpp>
+#include <vortex_msgs/action/guidance_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
 #include "reference_filter_dp/lib/waypoint_follower.hpp"
@@ -36,17 +36,18 @@ class ReferenceFilterNode : public rclcpp::Node {
     /// @brief Accept all incoming goals unconditionally.
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
-        std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal);
+        std::shared_ptr<const vortex_msgs::action::GuidanceWaypoint::Goal>
+            goal);
 
     /// @brief Accept all cancel requests.
     rclcpp_action::CancelResponse handle_cancel(
-        const std::shared_ptr<
-            rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
-            goal_handle);
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     /// @brief Join the old execution thread and spawn a new one for the goal.
-    void handle_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                             vortex_msgs::action::SetWaypoint>> goal_handle);
+    void handle_accepted(
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     /**
      * @brief Execute the action goal in a loop until convergence or
@@ -54,9 +55,9 @@ class ReferenceFilterNode : public rclcpp::Node {
      * @param goal_handle The goal handle.
      */
     void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                     vortex_msgs::action::SetWaypoint>> goal_handle);
+                     vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
-    rclcpp_action::Server<vortex_msgs::action::SetWaypoint>::SharedPtr
+    rclcpp_action::Server<vortex_msgs::action::GuidanceWaypoint>::SharedPtr
         action_server_;
 
     ReferenceFilterParams filter_params_;

--- a/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp/include/reference_filter_dp/ros/reference_filter_ros.hpp
@@ -9,7 +9,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <vortex/utils/types.hpp>
-#include <vortex_msgs/action/reference_filter_waypoint.hpp>
+#include <vortex_msgs/action/set_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
 #include "reference_filter_dp/lib/waypoint_follower.hpp"
@@ -36,30 +36,28 @@ class ReferenceFilterNode : public rclcpp::Node {
     /// @brief Accept all incoming goals unconditionally.
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
-        std::shared_ptr<
-            const vortex_msgs::action::ReferenceFilterWaypoint::Goal> goal);
+        std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal);
 
     /// @brief Accept all cancel requests.
     rclcpp_action::CancelResponse handle_cancel(
-        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-            vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
+        const std::shared_ptr<
+            rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+            goal_handle);
 
     /// @brief Join the old execution thread and spawn a new one for the goal.
-    void handle_accepted(
-        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-            vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
+    void handle_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+                             vortex_msgs::action::SetWaypoint>> goal_handle);
 
     /**
      * @brief Execute the action goal in a loop until convergence or
      * preemption.
      * @param goal_handle The goal handle.
      */
-    void execute(
-        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-            vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle);
+    void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+                     vortex_msgs::action::SetWaypoint>> goal_handle);
 
-    rclcpp_action::Server<
-        vortex_msgs::action::ReferenceFilterWaypoint>::SharedPtr action_server_;
+    rclcpp_action::Server<vortex_msgs::action::SetWaypoint>::SharedPtr
+        action_server_;
 
     ReferenceFilterParams filter_params_;
 

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -92,7 +92,7 @@ void ReferenceFilterNode::set_action_server() {
         this->get_parameter("action_servers.reference_filter").as_string();
 
     action_server_ =
-        rclcpp_action::create_server<vortex_msgs::action::SetWaypoint>(
+        rclcpp_action::create_server<vortex_msgs::action::GuidanceWaypoint>(
             this, action_server_name,
             [this](const auto& uuid, auto goal) {
                 return handle_goal(uuid, std::move(goal));
@@ -119,7 +119,7 @@ void ReferenceFilterNode::set_refererence_filter() {
 
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
     const rclcpp_action::GoalUUID& /*uuid*/,
-    std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal>
+    std::shared_ptr<const vortex_msgs::action::GuidanceWaypoint::Goal>
     /*goal*/) {
     spdlog::info("Accepted goal request");
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -127,14 +127,14 @@ rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
 
 rclcpp_action::CancelResponse ReferenceFilterNode::handle_cancel(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::SetWaypoint>> /*goal_handle*/) {
+        vortex_msgs::action::GuidanceWaypoint>> /*goal_handle*/) {
     spdlog::info("Received request to cancel goal");
     return rclcpp_action::CancelResponse::ACCEPT;
 }
 
 void ReferenceFilterNode::handle_accepted(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     std::lock_guard<std::mutex> lock(execute_mutex_);
     preempted_ = true;
@@ -149,7 +149,7 @@ void ReferenceFilterNode::handle_accepted(
 
 void ReferenceFilterNode::execute(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     spdlog::info("Executing goal");
 
@@ -172,7 +172,8 @@ void ReferenceFilterNode::execute(
 
     follower_->start(pose, twist, wp, convergence_threshold);
 
-    auto result = std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
+    auto result =
+        std::make_shared<vortex_msgs::action::GuidanceWaypoint::Result>();
 
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 
@@ -224,7 +225,7 @@ void ReferenceFilterNode::execute(
     }
     if (!rclcpp::ok() && goal_handle->is_active()) {
         auto result =
-            std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
+            std::make_shared<vortex_msgs::action::GuidanceWaypoint::Result>();
         result->success = false;
 
         try {

--- a/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp/src/ros/reference_filter_ros.cpp
@@ -91,14 +91,14 @@ void ReferenceFilterNode::set_action_server() {
     std::string action_server_name =
         this->get_parameter("action_servers.reference_filter").as_string();
 
-    action_server_ = rclcpp_action::create_server<
-        vortex_msgs::action::ReferenceFilterWaypoint>(
-        this, action_server_name,
-        [this](const auto& uuid, auto goal) {
-            return handle_goal(uuid, std::move(goal));
-        },
-        [this](auto goal_handle) { return handle_cancel(goal_handle); },
-        [this](auto goal_handle) { handle_accepted(goal_handle); });
+    action_server_ =
+        rclcpp_action::create_server<vortex_msgs::action::SetWaypoint>(
+            this, action_server_name,
+            [this](const auto& uuid, auto goal) {
+                return handle_goal(uuid, std::move(goal));
+            },
+            [this](auto goal_handle) { return handle_cancel(goal_handle); },
+            [this](auto goal_handle) { handle_accepted(goal_handle); });
 }
 
 void ReferenceFilterNode::set_refererence_filter() {
@@ -119,7 +119,7 @@ void ReferenceFilterNode::set_refererence_filter() {
 
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
     const rclcpp_action::GoalUUID& /*uuid*/,
-    std::shared_ptr<const vortex_msgs::action::ReferenceFilterWaypoint::Goal>
+    std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal>
     /*goal*/) {
     spdlog::info("Accepted goal request");
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -127,14 +127,15 @@ rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
 
 rclcpp_action::CancelResponse ReferenceFilterNode::handle_cancel(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterWaypoint>> /*goal_handle*/) {
+        vortex_msgs::action::SetWaypoint>> /*goal_handle*/) {
     spdlog::info("Received request to cancel goal");
     return rclcpp_action::CancelResponse::ACCEPT;
 }
 
 void ReferenceFilterNode::handle_accepted(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle) {
+    const std::shared_ptr<
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        goal_handle) {
     std::lock_guard<std::mutex> lock(execute_mutex_);
     preempted_ = true;
     if (execute_thread_.joinable()) {
@@ -147,8 +148,9 @@ void ReferenceFilterNode::handle_accepted(
 }
 
 void ReferenceFilterNode::execute(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterWaypoint>> goal_handle) {
+    const std::shared_ptr<
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        goal_handle) {
     spdlog::info("Executing goal");
 
     double convergence_threshold =
@@ -170,8 +172,7 @@ void ReferenceFilterNode::execute(
 
     follower_->start(pose, twist, wp, convergence_threshold);
 
-    auto result = std::make_shared<
-        vortex_msgs::action::ReferenceFilterWaypoint::Result>();
+    auto result = std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
 
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 
@@ -222,8 +223,8 @@ void ReferenceFilterNode::execute(
         loop_rate.sleep();
     }
     if (!rclcpp::ok() && goal_handle->is_active()) {
-        auto result = std::make_shared<
-            vortex_msgs::action::ReferenceFilterWaypoint::Result>();
+        auto result =
+            std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
         result->success = false;
 
         try {

--- a/guidance/reference_filter_dp_quat/include/reference_filter_dp_quat/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp_quat/include/reference_filter_dp_quat/ros/reference_filter_ros.hpp
@@ -9,7 +9,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <vortex/utils/types.hpp>
-#include <vortex_msgs/action/reference_filter_quat_waypoint.hpp>
+#include <vortex_msgs/action/set_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/reference_filter_quat.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
@@ -37,30 +37,28 @@ class ReferenceFilterNode : public rclcpp::Node {
     /// @brief Accept all incoming goals unconditionally.
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
-        std::shared_ptr<
-            const vortex_msgs::action::ReferenceFilterQuatWaypoint::Goal> goal);
+        std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal);
 
     /// @brief Accept all cancel requests.
     rclcpp_action::CancelResponse handle_cancel(
-        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-            vortex_msgs::action::ReferenceFilterQuatWaypoint>> goal_handle);
+        const std::shared_ptr<
+            rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+            goal_handle);
 
     /// @brief Join the old execution thread and spawn a new one for the goal.
-    void handle_accepted(
-        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-            vortex_msgs::action::ReferenceFilterQuatWaypoint>> goal_handle);
+    void handle_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+                             vortex_msgs::action::SetWaypoint>> goal_handle);
 
     /**
      * @brief Execute the action goal in a loop until convergence or
      * preemption.
      * @param goal_handle The goal handle.
      */
-    void execute(
-        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-            vortex_msgs::action::ReferenceFilterQuatWaypoint>> goal_handle);
+    void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+                     vortex_msgs::action::SetWaypoint>> goal_handle);
 
-    rclcpp_action::Server<vortex_msgs::action::ReferenceFilterQuatWaypoint>::
-        SharedPtr action_server_;
+    rclcpp_action::Server<vortex_msgs::action::SetWaypoint>::SharedPtr
+        action_server_;
 
     ReferenceFilterParams filter_params_;
 

--- a/guidance/reference_filter_dp_quat/include/reference_filter_dp_quat/ros/reference_filter_ros.hpp
+++ b/guidance/reference_filter_dp_quat/include/reference_filter_dp_quat/ros/reference_filter_ros.hpp
@@ -9,7 +9,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <vortex/utils/types.hpp>
-#include <vortex_msgs/action/set_waypoint.hpp>
+#include <vortex_msgs/action/guidance_waypoint.hpp>
 #include <vortex_msgs/msg/reference_filter.hpp>
 #include <vortex_msgs/msg/reference_filter_quat.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
@@ -37,17 +37,18 @@ class ReferenceFilterNode : public rclcpp::Node {
     /// @brief Accept all incoming goals unconditionally.
     rclcpp_action::GoalResponse handle_goal(
         const rclcpp_action::GoalUUID& uuid,
-        std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal> goal);
+        std::shared_ptr<const vortex_msgs::action::GuidanceWaypoint::Goal>
+            goal);
 
     /// @brief Accept all cancel requests.
     rclcpp_action::CancelResponse handle_cancel(
-        const std::shared_ptr<
-            rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
-            goal_handle);
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     /// @brief Join the old execution thread and spawn a new one for the goal.
-    void handle_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                             vortex_msgs::action::SetWaypoint>> goal_handle);
+    void handle_accepted(
+        const std::shared_ptr<rclcpp_action::ServerGoalHandle<
+            vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
     /**
      * @brief Execute the action goal in a loop until convergence or
@@ -55,9 +56,9 @@ class ReferenceFilterNode : public rclcpp::Node {
      * @param goal_handle The goal handle.
      */
     void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-                     vortex_msgs::action::SetWaypoint>> goal_handle);
+                     vortex_msgs::action::GuidanceWaypoint>> goal_handle);
 
-    rclcpp_action::Server<vortex_msgs::action::SetWaypoint>::SharedPtr
+    rclcpp_action::Server<vortex_msgs::action::GuidanceWaypoint>::SharedPtr
         action_server_;
 
     ReferenceFilterParams filter_params_;

--- a/guidance/reference_filter_dp_quat/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp_quat/src/ros/reference_filter_ros.cpp
@@ -100,14 +100,14 @@ void ReferenceFilterNode::set_action_server() {
     std::string action_server_name =
         this->get_parameter("action_servers.reference_filter").as_string();
 
-    action_server_ = rclcpp_action::create_server<
-        vortex_msgs::action::ReferenceFilterQuatWaypoint>(
-        this, action_server_name,
-        [this](const auto& uuid, auto goal) {
-            return handle_goal(uuid, std::move(goal));
-        },
-        [this](auto goal_handle) { return handle_cancel(goal_handle); },
-        [this](auto goal_handle) { handle_accepted(goal_handle); });
+    action_server_ =
+        rclcpp_action::create_server<vortex_msgs::action::SetWaypoint>(
+            this, action_server_name,
+            [this](const auto& uuid, auto goal) {
+                return handle_goal(uuid, std::move(goal));
+            },
+            [this](auto goal_handle) { return handle_cancel(goal_handle); },
+            [this](auto goal_handle) { handle_accepted(goal_handle); });
 }
 
 void ReferenceFilterNode::set_refererence_filter() {
@@ -128,8 +128,7 @@ void ReferenceFilterNode::set_refererence_filter() {
 
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
     const rclcpp_action::GoalUUID& /*uuid*/,
-    std::shared_ptr<
-        const vortex_msgs::action::ReferenceFilterQuatWaypoint::Goal>
+    std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal>
     /*goal*/) {
     spdlog::info("Accepted goal request");
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -137,14 +136,15 @@ rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
 
 rclcpp_action::CancelResponse ReferenceFilterNode::handle_cancel(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterQuatWaypoint>> /*goal_handle*/) {
+        vortex_msgs::action::SetWaypoint>> /*goal_handle*/) {
     spdlog::info("Received request to cancel goal");
     return rclcpp_action::CancelResponse::ACCEPT;
 }
 
 void ReferenceFilterNode::handle_accepted(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterQuatWaypoint>> goal_handle) {
+    const std::shared_ptr<
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        goal_handle) {
     std::lock_guard<std::mutex> lock(execute_mutex_);
     preempted_ = true;
     if (execute_thread_.joinable()) {
@@ -157,8 +157,9 @@ void ReferenceFilterNode::handle_accepted(
 }
 
 void ReferenceFilterNode::execute(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::ReferenceFilterQuatWaypoint>> goal_handle) {
+    const std::shared_ptr<
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        goal_handle) {
     spdlog::info("Executing goal");
 
     double convergence_threshold =
@@ -181,8 +182,7 @@ void ReferenceFilterNode::execute(
 
     follower_->start(pose, twist, wp, convergence_threshold);
 
-    auto result = std::make_shared<
-        vortex_msgs::action::ReferenceFilterQuatWaypoint::Result>();
+    auto result = std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
 
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 
@@ -238,8 +238,8 @@ void ReferenceFilterNode::execute(
         loop_rate.sleep();
     }
     if (!rclcpp::ok() && goal_handle->is_active()) {
-        auto result = std::make_shared<
-            vortex_msgs::action::ReferenceFilterQuatWaypoint::Result>();
+        auto result =
+            std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
         result->success = false;
 
         try {

--- a/guidance/reference_filter_dp_quat/src/ros/reference_filter_ros.cpp
+++ b/guidance/reference_filter_dp_quat/src/ros/reference_filter_ros.cpp
@@ -101,7 +101,7 @@ void ReferenceFilterNode::set_action_server() {
         this->get_parameter("action_servers.reference_filter").as_string();
 
     action_server_ =
-        rclcpp_action::create_server<vortex_msgs::action::SetWaypoint>(
+        rclcpp_action::create_server<vortex_msgs::action::GuidanceWaypoint>(
             this, action_server_name,
             [this](const auto& uuid, auto goal) {
                 return handle_goal(uuid, std::move(goal));
@@ -128,7 +128,7 @@ void ReferenceFilterNode::set_refererence_filter() {
 
 rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
     const rclcpp_action::GoalUUID& /*uuid*/,
-    std::shared_ptr<const vortex_msgs::action::SetWaypoint::Goal>
+    std::shared_ptr<const vortex_msgs::action::GuidanceWaypoint::Goal>
     /*goal*/) {
     spdlog::info("Accepted goal request");
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -136,14 +136,14 @@ rclcpp_action::GoalResponse ReferenceFilterNode::handle_goal(
 
 rclcpp_action::CancelResponse ReferenceFilterNode::handle_cancel(
     const std::shared_ptr<rclcpp_action::ServerGoalHandle<
-        vortex_msgs::action::SetWaypoint>> /*goal_handle*/) {
+        vortex_msgs::action::GuidanceWaypoint>> /*goal_handle*/) {
     spdlog::info("Received request to cancel goal");
     return rclcpp_action::CancelResponse::ACCEPT;
 }
 
 void ReferenceFilterNode::handle_accepted(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     std::lock_guard<std::mutex> lock(execute_mutex_);
     preempted_ = true;
@@ -158,7 +158,7 @@ void ReferenceFilterNode::handle_accepted(
 
 void ReferenceFilterNode::execute(
     const std::shared_ptr<
-        rclcpp_action::ServerGoalHandle<vortex_msgs::action::SetWaypoint>>
+        rclcpp_action::ServerGoalHandle<vortex_msgs::action::GuidanceWaypoint>>
         goal_handle) {
     spdlog::info("Executing goal");
 
@@ -182,7 +182,8 @@ void ReferenceFilterNode::execute(
 
     follower_->start(pose, twist, wp, convergence_threshold);
 
-    auto result = std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
+    auto result =
+        std::make_shared<vortex_msgs::action::GuidanceWaypoint::Result>();
 
     rclcpp::Rate loop_rate(1000.0 / time_step_.count());
 
@@ -239,7 +240,7 @@ void ReferenceFilterNode::execute(
     }
     if (!rclcpp::ok() && goal_handle->is_active()) {
         auto result =
-            std::make_shared<vortex_msgs::action::SetWaypoint::Result>();
+            std::make_shared<vortex_msgs::action::GuidanceWaypoint::Result>();
         result->success = false;
 
         try {

--- a/mission/landmark_server/include/landmark_server/landmark_server_ros.hpp
+++ b/mission/landmark_server/include/landmark_server/landmark_server_ros.hpp
@@ -16,9 +16,9 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp_action/client.hpp>
 #include <rclcpp_action/server_goal_handle.hpp>
+#include <vortex_msgs/action/guidance_waypoint.hpp>
 #include <vortex_msgs/action/landmark_convergence.hpp>
 #include <vortex_msgs/action/landmark_polling.hpp>
-#include <vortex_msgs/action/set_waypoint.hpp>
 #include <vortex_msgs/msg/landmark_array.hpp>
 #include <vortex_msgs/msg/landmark_track_array.hpp>
 #include <vortex_msgs/msg/waypoint_mode.hpp>
@@ -37,11 +37,11 @@ using LandmarkPollingGoalHandle =
 using LandmarkConvergenceGoalHandle =
     rclcpp_action::ServerGoalHandle<vortex_msgs::action::LandmarkConvergence>;
 using ReferenceFilterGoalHandle =
-    rclcpp_action::ClientGoalHandle<vortex_msgs::action::SetWaypoint>;
+    rclcpp_action::ClientGoalHandle<vortex_msgs::action::GuidanceWaypoint>;
 
 using vortex::filtering::Landmark;
 
-using RF = vortex_msgs::action::SetWaypoint;
+using RF = vortex_msgs::action::GuidanceWaypoint;
 
 class LandmarkServerNode : public rclcpp::Node {
    public:
@@ -116,12 +116,12 @@ class LandmarkServerNode : public rclcpp::Node {
         const std::shared_ptr<rclcpp_action::ServerGoalHandle<
             vortex_msgs::action::LandmarkConvergence>> goal_handle);
 
-    vortex_msgs::action::SetWaypoint::Goal make_rf_goal(
+    vortex_msgs::action::GuidanceWaypoint::Goal make_rf_goal(
         const geometry_msgs::msg::Pose& target,
         double convergence_threshold) const;
 
     void send_reference_filter_goal(
-        const vortex_msgs::action::SetWaypoint::Goal& goal_msg,
+        const vortex_msgs::action::GuidanceWaypoint::Goal& goal_msg,
         uint64_t seq);
 
     geometry_msgs::msg::Pose compute_target_pose(
@@ -156,7 +156,7 @@ class LandmarkServerNode : public rclcpp::Node {
     rclcpp_action::Server<vortex_msgs::action::LandmarkConvergence>::SharedPtr
         landmark_convergence_server_;
 
-    rclcpp_action::Client<vortex_msgs::action::SetWaypoint>::SharedPtr
+    rclcpp_action::Client<vortex_msgs::action::GuidanceWaypoint>::SharedPtr
         reference_filter_client_;
 
     std::unique_ptr<vortex::filtering::PoseTrackManager> track_manager_;

--- a/mission/landmark_server/include/landmark_server/landmark_server_ros.hpp
+++ b/mission/landmark_server/include/landmark_server/landmark_server_ros.hpp
@@ -18,7 +18,7 @@
 #include <rclcpp_action/server_goal_handle.hpp>
 #include <vortex_msgs/action/landmark_convergence.hpp>
 #include <vortex_msgs/action/landmark_polling.hpp>
-#include <vortex_msgs/action/reference_filter_waypoint.hpp>
+#include <vortex_msgs/action/set_waypoint.hpp>
 #include <vortex_msgs/msg/landmark_array.hpp>
 #include <vortex_msgs/msg/landmark_track_array.hpp>
 #include <vortex_msgs/msg/waypoint_mode.hpp>
@@ -36,12 +36,12 @@ using LandmarkPollingGoalHandle =
     rclcpp_action::ServerGoalHandle<vortex_msgs::action::LandmarkPolling>;
 using LandmarkConvergenceGoalHandle =
     rclcpp_action::ServerGoalHandle<vortex_msgs::action::LandmarkConvergence>;
-using ReferenceFilterGoalHandle = rclcpp_action::ClientGoalHandle<
-    vortex_msgs::action::ReferenceFilterWaypoint>;
+using ReferenceFilterGoalHandle =
+    rclcpp_action::ClientGoalHandle<vortex_msgs::action::SetWaypoint>;
 
 using vortex::filtering::Landmark;
 
-using RF = vortex_msgs::action::ReferenceFilterWaypoint;
+using RF = vortex_msgs::action::SetWaypoint;
 
 class LandmarkServerNode : public rclcpp::Node {
    public:
@@ -116,12 +116,12 @@ class LandmarkServerNode : public rclcpp::Node {
         const std::shared_ptr<rclcpp_action::ServerGoalHandle<
             vortex_msgs::action::LandmarkConvergence>> goal_handle);
 
-    vortex_msgs::action::ReferenceFilterWaypoint::Goal make_rf_goal(
+    vortex_msgs::action::SetWaypoint::Goal make_rf_goal(
         const geometry_msgs::msg::Pose& target,
         double convergence_threshold) const;
 
     void send_reference_filter_goal(
-        const vortex_msgs::action::ReferenceFilterWaypoint::Goal& goal_msg,
+        const vortex_msgs::action::SetWaypoint::Goal& goal_msg,
         uint64_t seq);
 
     geometry_msgs::msg::Pose compute_target_pose(
@@ -156,8 +156,8 @@ class LandmarkServerNode : public rclcpp::Node {
     rclcpp_action::Server<vortex_msgs::action::LandmarkConvergence>::SharedPtr
         landmark_convergence_server_;
 
-    rclcpp_action::Client<vortex_msgs::action::ReferenceFilterWaypoint>::
-        SharedPtr reference_filter_client_;
+    rclcpp_action::Client<vortex_msgs::action::SetWaypoint>::SharedPtr
+        reference_filter_client_;
 
     std::unique_ptr<vortex::filtering::PoseTrackManager> track_manager_;
 

--- a/mission/landmark_server/src/landmark_server_convergence.cpp
+++ b/mission/landmark_server/src/landmark_server_convergence.cpp
@@ -287,10 +287,10 @@ void LandmarkServerNode::convergence_try_dead_reckoning_handoff() {
     }
 }
 
-vortex_msgs::action::SetWaypoint::Goal LandmarkServerNode::make_rf_goal(
+vortex_msgs::action::GuidanceWaypoint::Goal LandmarkServerNode::make_rf_goal(
     const geometry_msgs::msg::Pose& target,
     double convergence_threshold) const {
-    vortex_msgs::action::SetWaypoint::Goal rf_goal;
+    vortex_msgs::action::GuidanceWaypoint::Goal rf_goal;
     vortex_msgs::msg::Waypoint wp;
     wp.pose = target;
     wp.waypoint_mode = convergence_mode_;
@@ -300,7 +300,7 @@ vortex_msgs::action::SetWaypoint::Goal LandmarkServerNode::make_rf_goal(
 }
 
 void LandmarkServerNode::send_reference_filter_goal(
-    const vortex_msgs::action::SetWaypoint::Goal& goal_msg,
+    const vortex_msgs::action::GuidanceWaypoint::Goal& goal_msg,
     uint64_t session_id) {
     cancel_reference_filter_goal();
 

--- a/mission/landmark_server/src/landmark_server_convergence.cpp
+++ b/mission/landmark_server/src/landmark_server_convergence.cpp
@@ -287,10 +287,10 @@ void LandmarkServerNode::convergence_try_dead_reckoning_handoff() {
     }
 }
 
-vortex_msgs::action::ReferenceFilterWaypoint::Goal
-LandmarkServerNode::make_rf_goal(const geometry_msgs::msg::Pose& target,
-                                 double convergence_threshold) const {
-    vortex_msgs::action::ReferenceFilterWaypoint::Goal rf_goal;
+vortex_msgs::action::SetWaypoint::Goal LandmarkServerNode::make_rf_goal(
+    const geometry_msgs::msg::Pose& target,
+    double convergence_threshold) const {
+    vortex_msgs::action::SetWaypoint::Goal rf_goal;
     vortex_msgs::msg::Waypoint wp;
     wp.pose = target;
     wp.waypoint_mode = convergence_mode_;
@@ -300,7 +300,7 @@ LandmarkServerNode::make_rf_goal(const geometry_msgs::msg::Pose& target,
 }
 
 void LandmarkServerNode::send_reference_filter_goal(
-    const vortex_msgs::action::ReferenceFilterWaypoint::Goal& goal_msg,
+    const vortex_msgs::action::SetWaypoint::Goal& goal_msg,
     uint64_t session_id) {
     cancel_reference_filter_goal();
 

--- a/mission/landmark_server/src/landmark_server_ros.cpp
+++ b/mission/landmark_server/src/landmark_server_ros.cpp
@@ -165,7 +165,7 @@ void LandmarkServerNode::create_reference_action_client() {
     std::string reference_action_name =
         this->declare_parameter<std::string>("action_servers.reference_filter");
     reference_filter_client_ =
-        rclcpp_action::create_client<vortex_msgs::action::SetWaypoint>(
+        rclcpp_action::create_client<vortex_msgs::action::GuidanceWaypoint>(
             this, reference_action_name);
     if (!reference_filter_client_->wait_for_action_server(
             std::chrono::seconds(3))) {

--- a/mission/landmark_server/src/landmark_server_ros.cpp
+++ b/mission/landmark_server/src/landmark_server_ros.cpp
@@ -9,6 +9,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <vortex/utils/ros/qos_profiles.hpp>
 #include <vortex/utils/ros/ros_transforms.hpp>
+#include <vortex_msgs/action/detail/set_waypoint__struct.hpp>
 
 const auto start_msg = R"(
 ██       █████  ███    ██ ██████  ███    ███  █████  ██████  ██   ██     ███████ ███████ ██████  ██    ██ ███████ ██████
@@ -163,9 +164,9 @@ void LandmarkServerNode::create_convergence_action_server() {
 void LandmarkServerNode::create_reference_action_client() {
     std::string reference_action_name =
         this->declare_parameter<std::string>("action_servers.reference_filter");
-    reference_filter_client_ = rclcpp_action::create_client<
-        vortex_msgs::action::ReferenceFilterWaypoint>(this,
-                                                      reference_action_name);
+    reference_filter_client_ =
+        rclcpp_action::create_client<vortex_msgs::action::SetWaypoint>(
+            this, reference_action_name);
     if (!reference_filter_client_->wait_for_action_server(
             std::chrono::seconds(3))) {
         spdlog::warn("ReferenceFilter server not ready");

--- a/mission/waypoint_manager/include/waypoint_manager/waypoint_manager_ros.hpp
+++ b/mission/waypoint_manager/include/waypoint_manager/waypoint_manager_ros.hpp
@@ -6,7 +6,7 @@
 #include <rclcpp_action/rclcpp_action.hpp>
 
 #include <vector>
-#include <vortex_msgs/action/reference_filter_waypoint.hpp>
+#include <vortex_msgs/action/set_waypoint.hpp>
 #include <vortex_msgs/action/waypoint_manager.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
 #include <vortex_msgs/srv/send_waypoints.hpp>
@@ -17,7 +17,7 @@ using WaypointManager = vortex_msgs::action::WaypointManager;
 using WaypointManagerGoalHandle =
     rclcpp_action::ServerGoalHandle<WaypointManager>;
 
-using ReferenceFilterAction = vortex_msgs::action::ReferenceFilterWaypoint;
+using ReferenceFilterAction = vortex_msgs::action::SetWaypoint;
 using ReferenceFilterGoalHandle =
     rclcpp_action::ClientGoalHandle<ReferenceFilterAction>;
 
@@ -88,10 +88,10 @@ class WaypointManagerNode : public rclcpp::Node {
     // @brief Send a goal to the reference filter
     // @param goal_msg The action goal
     void send_reference_filter_goal(
-        const vortex_msgs::action::ReferenceFilterWaypoint::Goal& goal_msg);
+        const vortex_msgs::action::SetWaypoint::Goal& goal_msg);
 
-    rclcpp_action::Client<vortex_msgs::action::ReferenceFilterWaypoint>::
-        SharedPtr reference_filter_client_;
+    rclcpp_action::Client<vortex_msgs::action::SetWaypoint>::SharedPtr
+        reference_filter_client_;
     rclcpp_action::Server<vortex_msgs::action::WaypointManager>::SharedPtr
         waypoint_action_server_;
     rclcpp::Service<vortex_msgs::srv::SendWaypoints>::SharedPtr

--- a/mission/waypoint_manager/include/waypoint_manager/waypoint_manager_ros.hpp
+++ b/mission/waypoint_manager/include/waypoint_manager/waypoint_manager_ros.hpp
@@ -6,7 +6,7 @@
 #include <rclcpp_action/rclcpp_action.hpp>
 
 #include <vector>
-#include <vortex_msgs/action/set_waypoint.hpp>
+#include <vortex_msgs/action/guidance_waypoint.hpp>
 #include <vortex_msgs/action/waypoint_manager.hpp>
 #include <vortex_msgs/msg/waypoint.hpp>
 #include <vortex_msgs/srv/send_waypoints.hpp>
@@ -17,7 +17,7 @@ using WaypointManager = vortex_msgs::action::WaypointManager;
 using WaypointManagerGoalHandle =
     rclcpp_action::ServerGoalHandle<WaypointManager>;
 
-using ReferenceFilterAction = vortex_msgs::action::SetWaypoint;
+using ReferenceFilterAction = vortex_msgs::action::GuidanceWaypoint;
 using ReferenceFilterGoalHandle =
     rclcpp_action::ClientGoalHandle<ReferenceFilterAction>;
 
@@ -88,9 +88,9 @@ class WaypointManagerNode : public rclcpp::Node {
     // @brief Send a goal to the reference filter
     // @param goal_msg The action goal
     void send_reference_filter_goal(
-        const vortex_msgs::action::SetWaypoint::Goal& goal_msg);
+        const vortex_msgs::action::GuidanceWaypoint::Goal& goal_msg);
 
-    rclcpp_action::Client<vortex_msgs::action::SetWaypoint>::SharedPtr
+    rclcpp_action::Client<vortex_msgs::action::GuidanceWaypoint>::SharedPtr
         reference_filter_client_;
     rclcpp_action::Server<vortex_msgs::action::WaypointManager>::SharedPtr
         waypoint_action_server_;

--- a/tests/ros_node_tests/los_node_test.sh
+++ b/tests/ros_node_tests/los_node_test.sh
@@ -31,7 +31,7 @@ fi
 
 # Send action goal
 echo "Sending goal..."
-ros2 action send_goal /$DRONE_ARG/los_guidance vortex_msgs/action/SetWaypoint "{waypoint: {pose: {position: {x: 20.0, y: 20.0, z: 5.0}}}, convergence_threshold: 0.5}" &
+ros2 action send_goal /$DRONE_ARG/los_guidance vortex_msgs/action/GuidanceWaypoint "{waypoint: {pose: {position: {x: 20.0, y: 20.0, z: 5.0}}}, convergence_threshold: 0.5}" &
 
 # Check if node correctly publishes guidance
 echo "Waiting for guidance data..."

--- a/tests/ros_node_tests/los_node_test.sh
+++ b/tests/ros_node_tests/los_node_test.sh
@@ -31,7 +31,8 @@ fi
 
 # Send action goal
 echo "Sending goal..."
-ros2 action send_goal /$DRONE_ARG/los_guidance vortex_msgs/action/LOSGuidance "{goal: {point: {x: 20.0, y: 20.0, z: 5.0}}}" &
+ros2 action send_goal /$DRONE_ARG/los_guidance vortex_msgs/action/SetWaypoint "{waypoint: {pose: {position: {x: 20.0, y: 20.0, z: 5.0}}}, convergence_threshold: 0.5}" &
+
 # Check if node correctly publishes guidance
 echo "Waiting for guidance data..."
 timeout 10s ros2 topic echo /$DRONE_ARG/guidance/los --once

--- a/tests/ros_node_tests/reference_filter_node_test.sh
+++ b/tests/ros_node_tests/reference_filter_node_test.sh
@@ -31,7 +31,7 @@ fi
 
 # Send action goal
 echo "Sending goal..."
-ros2 action send_goal /$DRONE_ARG/reference_filter vortex_msgs/action/SetWaypoint \
+ros2 action send_goal /$DRONE_ARG/reference_filter vortex_msgs/action/GuidanceWaypoint \
     "{waypoint: {pose: {position: {x: 1.0, y: 0.0, z: 0.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}, waypoint_mode: {mode: 0}}, convergence_threshold: 0.5}" &
 sleep 2
 

--- a/tests/ros_node_tests/reference_filter_node_test.sh
+++ b/tests/ros_node_tests/reference_filter_node_test.sh
@@ -31,9 +31,8 @@ fi
 
 # Send action goal
 echo "Sending goal..."
-ros2 action send_goal /$DRONE_ARG/reference_filter vortex_msgs/action/ReferenceFilterWaypoint \
-    "{waypoint: {pose: {position: {x: 1.0,y: 0.0,z: 0.0}, orientation:{x: 0,y: 0,z: 0,w: 1}}, waypoint_mode: {mode: 0}}}" &
-
+ros2 action send_goal /$DRONE_ARG/reference_filter vortex_msgs/action/SetWaypoint \
+    "{waypoint: {pose: {position: {x: 1.0, y: 0.0, z: 0.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}, waypoint_mode: {mode: 0}}, convergence_threshold: 0.5}" &
 sleep 2
 
 # Check if controller correctly publishes guidance

--- a/tests/simulator_tests/los_test/send_goal.py
+++ b/tests/simulator_tests/los_test/send_goal.py
@@ -1,23 +1,23 @@
 import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import LOSGuidance
+from vortex_msgs.action import SetWaypoint
 
 
 class LOSGuidanceClient(Node):
     def __init__(self):
         super().__init__('los_guidance_client')
         # Create the action client
-        self._action_client = ActionClient(self, LOSGuidance, '/nautilus/los_guidance')
+        self._action_client = ActionClient(self, SetWaypoint, '/nautilus/los_guidance')
         self.send_goal()
 
     def send_goal(self):
-        goal_msg = LOSGuidance.Goal()
+        goal_msg = SetWaypoint.Goal()
 
         # Create a message with the goal
-        goal_msg.goal.point.x = 20.0
-        goal_msg.goal.point.y = 20.0
-        goal_msg.goal.point.z = 5.0
+        goal_msg.waypoint.pose.position.x = 20.0
+        goal_msg.waypoint.pose.position.y = 20.0
+        goal_msg.waypoint.pose.position.z = 5.0
 
         # Send the goal asynchronously
         self._action_client.wait_for_server(timeout_sec=10.0)

--- a/tests/simulator_tests/los_test/send_goal.py
+++ b/tests/simulator_tests/los_test/send_goal.py
@@ -1,18 +1,20 @@
 import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import SetWaypoint
+from vortex_msgs.action import GuidanceWaypoint
 
 
 class LOSGuidanceClient(Node):
     def __init__(self):
         super().__init__('los_guidance_client')
         # Create the action client
-        self._action_client = ActionClient(self, SetWaypoint, '/nautilus/los_guidance')
+        self._action_client = ActionClient(
+            self, GuidanceWaypoint, '/nautilus/los_guidance'
+        )
         self.send_goal()
 
     def send_goal(self):
-        goal_msg = SetWaypoint.Goal()
+        goal_msg = GuidanceWaypoint.Goal()
 
         # Create a message with the goal
         goal_msg.waypoint.pose.position.x = 20.0

--- a/tests/simulator_tests/waypoint_manager_test/send_goal.py
+++ b/tests/simulator_tests/waypoint_manager_test/send_goal.py
@@ -4,7 +4,7 @@ import rclpy
 import yaml
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import SetWaypoint
+from vortex_msgs.action import GuidanceWaypoint
 from vortex_utils.python_utils import PoseData, euler_to_quat
 
 
@@ -25,13 +25,13 @@ class ReferenceFilterWaypointClient(Node):
         super().__init__('reference_filter_waypoint_client')
 
         self._action_client = ActionClient(
-            self, SetWaypoint, '/nautilus/reference_filter'
+            self, GuidanceWaypoint, '/nautilus/reference_filter'
         )
         self.send_goal()
 
     def send_goal(self):
         goal_pose = randomize_pose()
-        goal_msg = SetWaypoint.Goal()
+        goal_msg = GuidanceWaypoint.Goal()
         goal_msg.waypoint.pose.position.x = goal_pose.x
         goal_msg.waypoint.pose.position.y = goal_pose.y
         goal_msg.waypoint.pose.position.z = goal_pose.z

--- a/tests/simulator_tests/waypoint_manager_test/send_goal.py
+++ b/tests/simulator_tests/waypoint_manager_test/send_goal.py
@@ -4,7 +4,7 @@ import rclpy
 import yaml
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import ReferenceFilterWaypoint
+from vortex_msgs.action import SetWaypoint
 from vortex_utils.python_utils import PoseData, euler_to_quat
 
 
@@ -25,13 +25,13 @@ class ReferenceFilterWaypointClient(Node):
         super().__init__('reference_filter_waypoint_client')
 
         self._action_client = ActionClient(
-            self, ReferenceFilterWaypoint, '/nautilus/reference_filter'
+            self, SetWaypoint, '/nautilus/reference_filter'
         )
         self.send_goal()
 
     def send_goal(self):
         goal_pose = randomize_pose()
-        goal_msg = ReferenceFilterWaypoint.Goal()
+        goal_msg = SetWaypoint.Goal()
         goal_msg.waypoint.pose.position.x = goal_pose.x
         goal_msg.waypoint.pose.position.y = goal_pose.y
         goal_msg.waypoint.pose.position.z = goal_pose.z

--- a/tests/simulator_tests/waypoint_navigation/send_goal.py
+++ b/tests/simulator_tests/waypoint_navigation/send_goal.py
@@ -5,7 +5,7 @@ import rclpy
 import yaml
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import ReferenceFilterWaypoint
+from vortex_msgs.action import SetWaypoint
 from vortex_utils.python_utils import PoseData, euler_to_quat
 
 namespace = sys.argv[1] if len(sys.argv) > 1 else "nautilus"
@@ -28,13 +28,13 @@ class ReferenceFilterWaypointClient(Node):
         super().__init__('reference_filter_waypoint_client')
 
         self._action_client = ActionClient(
-            self, ReferenceFilterWaypoint, f'/{namespace}/reference_filter'
+            self, SetWaypoint, f'/{namespace}/reference_filter'
         )
         self.send_goal()
 
     def send_goal(self):
         goal_pose = randomize_pose()
-        goal_msg = ReferenceFilterWaypoint.Goal()
+        goal_msg = SetWaypoint.Goal()
 
         goal_msg.waypoint.pose.position.x = goal_pose.x
         goal_msg.waypoint.pose.position.y = goal_pose.y

--- a/tests/simulator_tests/waypoint_navigation/send_goal.py
+++ b/tests/simulator_tests/waypoint_navigation/send_goal.py
@@ -5,7 +5,7 @@ import rclpy
 import yaml
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import SetWaypoint
+from vortex_msgs.action import GuidanceWaypoint
 from vortex_utils.python_utils import PoseData, euler_to_quat
 
 namespace = sys.argv[1] if len(sys.argv) > 1 else "nautilus"
@@ -28,13 +28,13 @@ class ReferenceFilterWaypointClient(Node):
         super().__init__('reference_filter_waypoint_client')
 
         self._action_client = ActionClient(
-            self, SetWaypoint, f'/{namespace}/reference_filter'
+            self, GuidanceWaypoint, f'/{namespace}/reference_filter'
         )
         self.send_goal()
 
     def send_goal(self):
         goal_pose = randomize_pose()
-        goal_msg = SetWaypoint.Goal()
+        goal_msg = GuidanceWaypoint.Goal()
 
         goal_msg.waypoint.pose.position.x = goal_pose.x
         goal_msg.waypoint.pose.position.y = goal_pose.y

--- a/tests/simulator_tests/waypoint_navigation_quat/send_goal.py
+++ b/tests/simulator_tests/waypoint_navigation_quat/send_goal.py
@@ -4,7 +4,7 @@ import rclpy
 import yaml
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import ReferenceFilterQuatWaypoint
+from vortex_msgs.action import SetWaypoint
 from vortex_utils.python_utils import PoseData, euler_to_quat
 
 
@@ -25,13 +25,13 @@ class ReferenceFilterQuatWaypointClient(Node):
         super().__init__('reference_filter_quat_waypoint_client')
 
         self._action_client = ActionClient(
-            self, ReferenceFilterQuatWaypoint, '/nautilus/reference_filter'
+            self, SetWaypoint, '/nautilus/reference_filter'
         )
         self.send_goal()
 
     def send_goal(self):
         goal_pose = randomize_pose()
-        goal_msg = ReferenceFilterQuatWaypoint.Goal()
+        goal_msg = SetWaypoint.Goal()
 
         goal_msg.waypoint.pose.position.x = goal_pose.x
         goal_msg.waypoint.pose.position.y = goal_pose.y

--- a/tests/simulator_tests/waypoint_navigation_quat/send_goal.py
+++ b/tests/simulator_tests/waypoint_navigation_quat/send_goal.py
@@ -4,7 +4,7 @@ import rclpy
 import yaml
 from rclpy.action import ActionClient
 from rclpy.node import Node
-from vortex_msgs.action import SetWaypoint
+from vortex_msgs.action import GuidanceWaypoint
 from vortex_utils.python_utils import PoseData, euler_to_quat
 
 
@@ -25,13 +25,13 @@ class ReferenceFilterQuatWaypointClient(Node):
         super().__init__('reference_filter_quat_waypoint_client')
 
         self._action_client = ActionClient(
-            self, SetWaypoint, '/nautilus/reference_filter'
+            self, GuidanceWaypoint, '/nautilus/reference_filter'
         )
         self.send_goal()
 
     def send_goal(self):
         goal_pose = randomize_pose()
-        goal_msg = SetWaypoint.Goal()
+        goal_msg = GuidanceWaypoint.Goal()
 
         goal_msg.waypoint.pose.position.x = goal_pose.x
         goal_msg.waypoint.pose.position.y = goal_pose.y


### PR DESCRIPTION
his PR updates the waypoint action interface to use a shared vortex_msgs/SetWaypoint.action definition across all related components.

The previous separate action types used by LOS guidance and the reference filter are replaced so the waypoint sender can communicate through one common action interface without needing to switch action types depending on the target.

Updated components:

reference filter
reference filter DP quat

Changes included:
replace old action types with vortex_msgs/SetWaypoint.action
update related action server/client handling
update includes, dependencies, and field usage where needed
align all affected waypoint-consuming components to the same action interface